### PR TITLE
Improve supplement parsing and ECCN display

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -279,6 +279,13 @@ body {
   color: inherit;
 }
 
+.eccn-list-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
 .eccn-list li.active button,
 .eccn-list li button:hover {
   border-color: #2563eb;
@@ -294,6 +301,18 @@ body {
 .eccn-title {
   color: #4b5563;
   font-size: 0.9rem;
+}
+
+.eccn-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.05rem 0.6rem;
+  border-radius: 999px;
+  background: #dbeafe;
+  color: #1d4ed8;
+  font-size: 0.75rem;
+  font-weight: 600;
+  white-space: nowrap;
 }
 
 .eccn-detail {

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -21,6 +21,10 @@ export interface EccnEntry {
   category?: string | null;
   group?: string | null;
   breadcrumbs: string[];
+  supplement: {
+    number: string;
+    heading?: string | null;
+  };
   structure: EccnNode;
 }
 


### PR DESCRIPTION
## Summary
- add supplement-specific parsing for supplements 1, 5, 6, and 7 so each ECCN entry carries supplement metadata and captures list-style content
- surface supplement metadata on the frontend, flatten the ECCN list across supplements, and add filtering plus tags for the originating supplement

## Testing
- npm run build --prefix client

------
https://chatgpt.com/codex/tasks/task_e_68da9282d56c832fa4836c25ea5cce49