### PR TITLE
Parse ECCN sub-items into linked entries

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -389,6 +389,18 @@ function App() {
                                   : '–'}
                               </dd>
                             </div>
+                            <div>
+                              <dt>Parent ECCN</dt>
+                              <dd>{activeEccn.parentEccn ?? '–'}</dd>
+                            </div>
+                            <div>
+                              <dt>Child ECCNs</dt>
+                              <dd>
+                                {activeEccn.childEccns && activeEccn.childEccns.length > 0
+                                  ? activeEccn.childEccns.join(', ')
+                                  : '–'}
+                              </dd>
+                            </div>
                           </dl>
                         </header>
                         <EccnNodeView node={activeEccn.structure} />

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -26,6 +26,8 @@ export interface EccnEntry {
     heading?: string | null;
   };
   structure: EccnNode;
+  parentEccn?: string | null;
+  childEccns?: string[];
 }
 
 export interface SupplementMetadata {


### PR DESCRIPTION
## Summary
- extend the server-side ECCN parser to build hierarchical trees from supplement content and flatten them into discrete, linked entries for each sub-item
- surface parent/child ECCN relationships in the API payload and expose the metadata in the client detail view

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da9b919454832f946eeb11ca7e217f