### PR TITLE
Improve ECCN suffix parsing and range handling

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1181,15 +1181,22 @@ function extractEccnCodesFromText(text) {
 
   ECCN_BASE_PATTERN.lastIndex = 0;
 
+  let lastCode = null;
   let match;
   while ((match = ECCN_BASE_PATTERN.exec(text))) {
     const fullCode = sanitizeEccnCode(match[0]);
-    if (fullCode && !seen.has(fullCode)) {
+    if (!fullCode) {
+      continue;
+    }
+
+    if (!seen.has(fullCode)) {
       seen.add(fullCode);
       codes.push(fullCode);
     }
 
-    const root = fullCode ? fullCode.split('.')[0] : null;
+    lastCode = fullCode;
+
+    const root = fullCode.split('.')[0];
     if (!root) {
       continue;
     }
@@ -1197,11 +1204,12 @@ function extractEccnCodesFromText(text) {
     let tailIndex = ECCN_BASE_PATTERN.lastIndex;
     while (tailIndex < text.length) {
       const tail = text.slice(tailIndex);
-      const prefixMatch = tail.match(/^[\s,]*(?:and|or|to|through)?\s*/);
+      const prefixMatch = tail.match(/^[\s,;:–—\-()\[\]]*(and|or|to|through)?\s*/i);
       if (!prefixMatch) {
         break;
       }
 
+      const connector = prefixMatch[1] ? prefixMatch[1].toLowerCase() : null;
       const afterPrefix = tail.slice(prefixMatch[0].length);
       if (!afterPrefix.startsWith('.') && !/^[A-Za-z]\./.test(afterPrefix)) {
         break;
@@ -1214,18 +1222,31 @@ function extractEccnCodesFromText(text) {
 
       const suffix = segmentMatch[0];
       const normalizedSuffix = sanitizeSuffix(suffix);
+      const consumed = prefixMatch[0].length + segmentMatch[0].length;
+      tailIndex += consumed;
+
       if (!normalizedSuffix) {
-        tailIndex += prefixMatch[0].length + segmentMatch[0].length;
         continue;
       }
 
       const derived = `${root}${normalizedSuffix}`;
+
+      if ((connector === 'through' || connector === 'to') && lastCode) {
+        const rangeCodes = expandEccnRange(lastCode, derived);
+        for (const rangeCode of rangeCodes) {
+          if (!seen.has(rangeCode)) {
+            seen.add(rangeCode);
+            codes.push(rangeCode);
+          }
+        }
+      }
+
       if (!seen.has(derived)) {
         seen.add(derived);
         codes.push(derived);
       }
 
-      tailIndex += prefixMatch[0].length + segmentMatch[0].length;
+      lastCode = derived;
     }
   }
 
@@ -1236,11 +1257,47 @@ function sanitizeSuffix(suffix) {
   if (!suffix) {
     return null;
   }
-  const trimmed = suffix.replace(/^[\s,;:–—-]*/, '').replace(/[\s).,;:–—'"“”-]+$/g, '');
+  const trimmed = suffix
+    .replace(/^[\s,;:–—\-()\[\]]*/, '')
+    .replace(/[\s).,;:–—'"“”\-\]]+$/g, '');
   if (!trimmed) {
     return null;
   }
   return trimmed.startsWith('.') ? trimmed : `.${trimmed}`;
+}
+
+function expandEccnRange(startCode, endCode) {
+  if (!startCode || !endCode) {
+    return [];
+  }
+
+  const startParts = startCode.split('.');
+  const endParts = endCode.split('.');
+
+  if (startParts.length !== endParts.length) {
+    return [];
+  }
+
+  for (let i = 0; i < startParts.length - 1; i += 1) {
+    if (startParts[i] !== endParts[i]) {
+      return [];
+    }
+  }
+
+  const startValue = Number(startParts[startParts.length - 1]);
+  const endValue = Number(endParts[endParts.length - 1]);
+  if (!Number.isInteger(startValue) || !Number.isInteger(endValue) || startValue >= endValue) {
+    return [];
+  }
+
+  const prefix = startParts.slice(0, -1).join('.');
+  const results = [];
+  for (let value = startValue + 1; value < endValue; value += 1) {
+    const next = prefix ? `${prefix}.${value}` : String(value);
+    results.push(next);
+  }
+
+  return results;
 }
 
 function sanitizeEccnCode(code) {


### PR DESCRIPTION
## Summary
- broaden ECCN suffix parsing to accept semicolons, parentheses, and other contextual punctuation
- add handling for range connectors such as "through"/"to" so intermediate ECCNs are generated
- trim additional wrapper characters from suffixes and provide a helper to expand numeric ranges

## Testing
- `node - <<'NODE'
function sanitizeSuffix(suffix) {
  if (!suffix) {
    return null;
  }
  const trimmed = suffix
    .replace(/^[\s,;:–—\-()\[\]]*/, '')
    .replace(/[\s).,;:–—'"“”\-\]]+$/g, '');
  if (!trimmed) {
    return null;
  }
  return trimmed.startsWith('.') ? trimmed : `.${trimmed}`;
}

function expandEccnRange(startCode, endCode) {
  if (!startCode || !endCode) {
    return [];
  }

  const startParts = startCode.split('.');
  const endParts = endCode.split('.');

  if (startParts.length !== endParts.length) {
    return [];
  }

  for (let i = 0; i < startParts.length - 1; i += 1) {
    if (startParts[i] !== endParts[i]) {
      return [];
    }
  }

  const startValue = Number(startParts[startParts.length - 1]);
  const endValue = Number(endParts[endParts.length - 1]);
  if (!Number.isInteger(startValue) || !Number.isInteger(endValue) || startValue >= endValue) {
    return [];
  }

  const prefix = startParts.slice(0, -1).join('.');
  const results = [];
  for (let value = startValue + 1; value < endValue; value += 1) {
    const next = prefix ? `${prefix}.${value}` : String(value);
    results.push(next);
  }

  return results;
}

const ECCN_BASE_PATTERN = /[0-9][A-Z][0-9]{3}(?:\.[A-Za-z0-9]+)*/g;

function sanitizeEccnCode(code) {
  if (!code) {
    return null;
  }
  return code.replace(/[\s).,;:–—'"“”-]+$/g, '');
}

function extractEccnCodesFromText(text) {
  const codes = [];
  const seen = new Set();

  ECCN_BASE_PATTERN.lastIndex = 0;

  let lastCode = null;
  let match;
  while ((match = ECCN_BASE_PATTERN.exec(text))) {
    const fullCode = sanitizeEccnCode(match[0]);
    if (!fullCode) {
      continue;
    }

    if (!seen.has(fullCode)) {
      seen.add(fullCode);
      codes.push(fullCode);
    }

    lastCode = fullCode;

    const root = fullCode.split('.')[0];
    if (!root) {
      continue;
    }

    let tailIndex = ECCN_BASE_PATTERN.lastIndex;
    while (tailIndex < text.length) {
      const tail = text.slice(tailIndex);
      const prefixMatch = tail.match(/^[\s,;:–—\-()\[\]]*(and|or|to|through)?\s*/i);
      if (!prefixMatch) {
        break;
      }

      const connector = prefixMatch[1] ? prefixMatch[1].toLowerCase() : null;
      const afterPrefix = tail.slice(prefixMatch[0].length);
      if (!afterPrefix.startsWith('.') && !/^[A-Za-z]\./.test(afterPrefix)) {
        break;
      }

      const segmentMatch = afterPrefix.match(/^(?:\.[A-Za-z0-9]+(?:\.[A-Za-z0-9]+)*)|(?:[A-Za-z](?:\.[A-Za-z0-9]+)+)/);
      if (!segmentMatch) {
        break;
      }

      const suffix = segmentMatch[0];
      const normalizedSuffix = sanitizeSuffix(suffix);
      const consumed = prefixMatch[0].length + segmentMatch[0].length;
      tailIndex += consumed;

      if (!normalizedSuffix) {
        continue;
      }

      const derived = `${root}${normalizedSuffix}`;

      if ((connector === 'through' || connector === 'to') && lastCode) {
        const rangeCodes = expandEccnRange(lastCode, derived);
        for (const rangeCode of rangeCodes) {
          if (!seen.has(rangeCode)) {
            seen.add(rangeCode);
            codes.push(rangeCode);
          }
        }
      }

      if (!seen.has(derived)) {
        seen.add(derived);
        codes.push(derived);
      }

      lastCode = derived;
    }
  }

  return codes;
}

console.log(extractEccnCodesFromText('3B001.a.1, a.2, a.3, and a.4'));
console.log(extractEccnCodesFromText('3B001.a.1 through a.4'));
console.log(extractEccnCodesFromText('3B001.a.4.a and a.4.b'));
console.log(extractEccnCodesFromText('3B001.a.1; a.2; a.3; a.4'));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68daaaeff5f0832fad09116dd894814f