### PR TITLE
Strip trailing punctuation when normalizing ECCN content

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1009,7 +1009,16 @@ function normalizeComparableText(value) {
     return null;
   }
 
-  return value.replace(/\s+/g, ' ').trim().toLowerCase() || null;
+  const collapsed = value.replace(/\s+/g, ' ').trim();
+  if (!collapsed) {
+    return null;
+  }
+
+  const stripped = collapsed
+    .replace(/^["'“”‘’()\[\]{}\-–—:;,.!?]+/, '')
+    .replace(/["'“”‘’()\[\]{}\-–—:;,.!?]+$/, '');
+
+  return (stripped || collapsed).toLowerCase() || null;
 }
 
 function createTreeNode({ identifier, heading, path, parent }) {


### PR DESCRIPTION
## Summary
- strip leading and trailing punctuation when normalizing comparable text blocks so headings with punctuation variants are treated as duplicates
- keep ECCN descriptions focused on additional detail by preventing repeated titles such as 3B001.a and 3B001.b

## Testing
- node --test server/index.test.js

------
https://chatgpt.com/codex/tasks/task_e_68db3cccf614832f90c2c28082739ff1