### PR TITLE
Broaden detection for ECCNs requiring all criteria

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -270,7 +270,7 @@ function buildHeaders(accept) {
 
 const TARGET_SUPPLEMENTS = new Set(['1', '5', '6', '7']);
 const ECCN_HEADING_PATTERN = /^([0-9][A-Z][0-9]{3})(?=$|[\s.\-–—:;(\[])/;
-const ALL_OF_FOLLOWING_PATTERN = /\bhaving all of the following\b/i;
+const ALL_OF_FOLLOWING_PATTERN = /\ball of the following\b/i;
 
 function parsePart(xml) {
   const $ = load(xml, { xmlMode: true, decodeEntities: true });


### PR DESCRIPTION
## Summary
- treat any ECCN description that contains "all of the following" as requiring all child items
- ensure ECCNs using phrases like "perform all of the following" are covered

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db445caa50832fb0062cd6f0d8670b