### PR TITLE
Replace supplement filter dropdown with checkboxes

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -87,6 +87,32 @@ body {
   gap: 0.5rem;
 }
 
+.control-label {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: #111827;
+}
+
+.checkbox-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.checkbox-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  color: #374151;
+}
+
+.checkbox-option input[type='checkbox'] {
+  width: 1rem;
+  height: 1rem;
+  accent-color: #2563eb;
+}
+
 .inline-controls {
   display: flex;
   gap: 0.5rem;

--- a/client/src/components/VersionControls.tsx
+++ b/client/src/components/VersionControls.tsx
@@ -124,10 +124,6 @@ export function VersionControls({
                     <dd>{formatDateTime(version.fetchedAt)}</dd>
                   </div>
                   <div>
-                    <dt>Supplements</dt>
-                    <dd>{formatNumber(version.counts?.supplements ?? 0)}</dd>
-                  </div>
-                  <div>
                     <dt>ECCNs</dt>
                     <dd>{formatNumber(version.counts?.eccns ?? 0)}</dd>
                   </div>


### PR DESCRIPTION
## Summary
- remove the "Supplements parsed" metric from the dataset summary
- replace the supplement dropdown filter with multi-select checkboxes that default to all supplements
- update filtering logic and styles to match the new control layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db465ea648832fbe16177d6449e7d0