### PR TITLE
Fix note duplication and all-of-the-following parsing

### DIFF
--- a/server/index.test.js
+++ b/server/index.test.js
@@ -7,6 +7,7 @@ const {
   createTreeNode,
   flattenEccnTree,
   markNodeRequiresAllChildren,
+  parsePart,
 } = await import('./index.js');
 
 test('nodes marked as requiring all children suppress standalone ECCNs', () => {
@@ -21,6 +22,8 @@ test('nodes marked as requiring all children suppress standalone ECCNs', () => {
 
   const a4a = createTreeNode({ identifier: '3B001.a.4.a', heading: 'Requirement 1', path: ['a', '4', 'a'], parent: a4 });
   const a4b = createTreeNode({ identifier: '3B001.a.4.b', heading: 'Requirement 2', path: ['a', '4', 'b'], parent: a4 });
+  a4a.content.push({ type: 'text', text: 'a. Requirement 1 details' });
+  a4b.content.push({ type: 'text', text: 'b. Requirement 2 details' });
   a4.children.push(a4a, a4b);
 
   const entries = flattenEccnTree(root, {
@@ -40,6 +43,7 @@ test('nodes marked as requiring all children suppress standalone ECCNs', () => {
   assert(boundChild, 'bound child should remain in the parent structure');
   assert.equal(boundChild?.isEccn, true);
   assert.equal(boundChild?.boundToParent, true);
+  assert.equal(boundChild?.content?.[0]?.text, 'a. Requirement 1 details');
 });
 
 test('nodes without the phrase still produce standalone ECCNs for children', () => {
@@ -112,4 +116,56 @@ test('duplicate headings with enumerators are removed from structure content', (
     entry.structure.content?.[0].text,
     'Includes metal-organic chemical vapor deposition (MOCVD) systems.'
   );
+});
+
+test('parser handles notes, headings, and all-of-the-following blocks correctly', () => {
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<ROOT>
+  <DIV5 TYPE="PART" N="774">
+    <DIV9 TYPE="SUPPLEMENT" N="1">
+      <HEAD>Supplement No. 1 to Part 774—The Commerce Control List</HEAD>
+      <HD SOURCE="HED">Category 3 - Electronics</HD>
+      <P><B>3B001 Equipment</B></P>
+      <P ID="3b001d"><E T="03">d.</E> Control systems for manufacturing</P>
+      <P ID="3b001d1"><E T="03">(1)</E> Capable of positioning wafers with nanometer precision</P>
+      <NOTE ID="note3b001d1"><P>Note to 3B001.d.1: Additional application guidance.</P></NOTE>
+      <P ID="3b001d1ii"><E T="03">(ii)</E> With closed-loop feedback</P>
+      <P><B>3B993 Specially designed components</B></P>
+      <P ID="3b993f"><E T="03">(f)</E> Devices</P>
+      <P ID="3b993f4"><E T="03">(4)</E> All of the following:</P>
+      <P ID="3b993f4a"><E T="03">(a)</E> Component A with specific tolerances</P>
+      <P ID="3b993f4b"><E T="03">(b)</E> Component B capable of rapid alignment</P>
+    </DIV9>
+  </DIV5>
+</ROOT>`;
+
+  const { supplements } = parsePart(xml);
+  const supplement = supplements.find((entry) => entry.number === '1');
+  assert(supplement, 'expected supplement to be parsed');
+
+  const entries = supplement.eccns;
+
+  const dEntry = entries.find((entry) => entry.eccn === '3B001.d');
+  assert(dEntry, 'expected 3B001.d to be parsed');
+  assert.equal(dEntry.heading, 'Control systems for manufacturing');
+  assert.equal(dEntry.structure.label, '3B001.d – Control systems for manufacturing');
+
+  const d1Entry = entries.find((entry) => entry.eccn === '3B001.d.1');
+  assert(d1Entry, 'expected 3B001.d.1 to be parsed');
+  const noteBlocks = (d1Entry.structure.content || []).filter((block) =>
+    block.text?.startsWith('Note to 3B001.d.1:')
+  );
+  assert.equal(noteBlocks.length, 1, 'note should only appear once');
+
+  const f4Entry = entries.find((entry) => entry.eccn === '3B993.f.4');
+  assert(f4Entry, 'expected 3B993.f.4 to be parsed');
+  assert.deepEqual(f4Entry.childEccns, [], 'children should be suppressed for all-of-the-following');
+  const suppressedChildren = f4Entry.structure.children || [];
+  const childIds = suppressedChildren.map((child) => child.identifier);
+  assert.deepEqual(childIds.sort(), ['3B993.f.4.a', '3B993.f.4.b']);
+  const childAText = suppressedChildren.find((child) => child.identifier === '3B993.f.4.a')?.content?.[0]?.text;
+  assert(childAText?.includes('Component A with specific tolerances'));
+
+  const suppressedEntries = entries.filter((entry) => entry.eccn.startsWith('3B993.f.4.'));
+  assert.equal(suppressedEntries.length, 0, 'child ECCNs should not produce standalone entries');
 });


### PR DESCRIPTION
## Summary
- stop traversing NOTE elements once captured and keep content for nodes bound to their parent
- normalize derived paragraph headings to remove ECCN prefixes before labeling entries
- add regression coverage for notes, heading cleanup, and all-of-the-following suppression cases

## Testing
- node --test index.test.js

------
https://chatgpt.com/codex/tasks/task_e_68db4a161394832fb4940363dcc1da9b