### PR TITLE
Style ECCN identifiers in accordion

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -399,10 +399,35 @@ body {
   color: #1f2937;
 }
 
-.eccn-node.static .node-label {
-  display: block;
+.eccn-node .node-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
   font-weight: 600;
   color: #1f2937;
+}
+
+.eccn-node .node-identifier {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.1rem 0.45rem;
+  border-radius: 0.4rem;
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  font-size: 0.95rem;
+  line-height: 1.2;
+}
+
+.eccn-node .node-heading {
+  display: inline-flex;
+  align-items: center;
+  line-height: 1.3;
+}
+
+.eccn-node.static .node-label {
   padding: 0.35rem 0;
 }
 

--- a/client/src/components/EccnNodeView.tsx
+++ b/client/src/components/EccnNodeView.tsx
@@ -15,13 +15,30 @@ export function EccnNodeView({ node, level = 0 }: EccnNodeViewProps) {
     setOpen(isAccordion ? level < 2 : true);
   }, [isAccordion, level, node.identifier]);
 
-  const label = useMemo(() => {
+  const labelText = useMemo(() => {
     const parts = [] as string[];
     if (node.identifier) parts.push(node.identifier);
     if (node.heading && node.heading !== node.identifier) parts.push(node.heading);
     if (!parts.length && node.label) parts.push(node.label);
+    if (!parts.length && node.heading) parts.push(node.heading);
     return parts.join(' – ') || 'Details';
   }, [node.identifier, node.heading, node.label]);
+
+  const labelIdentifier = node.identifier;
+  const labelHeading = useMemo(() => {
+    if (node.heading && node.heading !== node.identifier) {
+      return node.heading;
+    }
+    if (!node.identifier && node.heading) {
+      return node.heading;
+    }
+    if (!node.identifier && !node.heading && node.label) {
+      return node.label;
+    }
+    return undefined;
+  }, [node.heading, node.identifier, node.label]);
+
+  const labelFallback = !labelIdentifier && !labelHeading ? labelText : undefined;
 
   const anchorId = useMemo(() => {
     if (node.identifier) {
@@ -38,13 +55,21 @@ export function EccnNodeView({ node, level = 0 }: EccnNodeViewProps) {
   if (!isAccordion) {
     return (
       <div className={`eccn-node level-${level} static`} id={anchorId}>
-        {showLabel ? <div className="node-label">{label}</div> : null}
+        {showLabel ? (
+          <div className="node-label" aria-label={labelText} title={labelText}>
+            {labelIdentifier ? <span className="node-identifier">{labelIdentifier}</span> : null}
+            {labelHeading ? <span className="node-heading">{labelHeading}</span> : null}
+            {!labelIdentifier && !labelHeading ? (
+              <span className="node-heading">{labelFallback}</span>
+            ) : null}
+          </div>
+        ) : null}
         <div className="node-body">
           {node.content?.map((entry, index) => (
-            <ContentBlock entry={entry} key={`${anchorId || label}-content-${index}`} />
+            <ContentBlock entry={entry} key={`${anchorId || labelText}-content-${index}`} />
           ))}
           {node.children?.map((child, index) => (
-            <EccnNodeView node={child} level={level + 1} key={`${anchorId || label}-child-${index}`} />
+            <EccnNodeView node={child} level={level + 1} key={`${anchorId || labelText}-child-${index}`} />
           ))}
         </div>
       </div>
@@ -59,14 +84,20 @@ export function EccnNodeView({ node, level = 0 }: EccnNodeViewProps) {
       id={anchorId}
     >
       <summary>
-        <span className="node-label">{label}</span>
+        <span className="node-label" aria-label={labelText} title={labelText}>
+          {labelIdentifier ? <span className="node-identifier">{labelIdentifier}</span> : null}
+          {labelHeading ? <span className="node-heading">{labelHeading}</span> : null}
+          {!labelIdentifier && !labelHeading ? (
+            <span className="node-heading">{labelFallback}</span>
+          ) : null}
+        </span>
       </summary>
       <div className="node-body">
         {node.content?.map((entry, index) => (
-          <ContentBlock entry={entry} key={`${anchorId || label}-content-${index}`} />
+          <ContentBlock entry={entry} key={`${anchorId || labelText}-content-${index}`} />
         ))}
         {node.children?.map((child, index) => (
-          <EccnNodeView node={child} level={level + 1} key={`${anchorId || label}-child-${index}`} />
+          <EccnNodeView node={child} level={level + 1} key={`${anchorId || labelText}-child-${index}`} />
         ))}
       </div>
     </details>


### PR DESCRIPTION
## Summary
- update ECCN node labels to render identifiers separately from headings
- add styling that highlights ECCN identifiers with a rounded rectangle treatment

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbc78b5248832f930b11ec689e4b23