### PR TITLE
Improve ECCN detail display and add reference links

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -383,10 +383,79 @@ body {
   color: #4b5563;
 }
 
+.eccn-high-level {
+  margin: 1.5rem 0;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.75rem;
+  background: #f9fafb;
+  overflow: hidden;
+}
+
+.eccn-high-level-row {
+  display: grid;
+  grid-template-columns: minmax(180px, 220px) 1fr;
+  gap: 0.5rem 1.5rem;
+  padding: 0.85rem 1rem;
+  border-top: 1px solid #e5e7eb;
+}
+
+.eccn-high-level-row:first-child {
+  border-top: none;
+}
+
+.eccn-high-level dt {
+  margin: 0;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.eccn-high-level dd {
+  margin: 0;
+  color: #1f2937;
+}
+
+.eccn-high-level .content {
+  margin: 0;
+}
+
+.eccn-high-level .content + .content {
+  margin-top: 0.5rem;
+}
+
+.eccn-high-level table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.eccn-high-level table th,
+.eccn-high-level table td {
+  border: 1px solid #d1d5db;
+  padding: 0.35rem 0.5rem;
+  text-align: left;
+}
+
+.eccn-high-level table thead th {
+  background: rgba(37, 99, 235, 0.1);
+  color: #1f2937;
+}
+
+.high-level-content {
+  margin: 0;
+}
+
 .eccn-node {
   border-left: 3px solid rgba(37, 99, 235, 0.25);
   margin-left: 0.5rem;
   padding-left: 0.75rem;
+}
+
+.eccn-node.active {
+  border-left-color: #2563eb;
+}
+
+.eccn-node.active-path:not(.active) {
+  border-left-color: rgba(37, 99, 235, 0.45);
 }
 
 .eccn-node summary {
@@ -406,6 +475,12 @@ body {
   flex-wrap: wrap;
   font-weight: 600;
   color: #1f2937;
+}
+
+.eccn-node.active .node-label {
+  background: rgba(37, 99, 235, 0.12);
+  border-radius: 0.4rem;
+  padding: 0.2rem 0.4rem;
 }
 
 .eccn-node .node-identifier {
@@ -436,6 +511,14 @@ body {
   border-left: 1px dashed rgba(37, 99, 235, 0.2);
   margin-left: 0.25rem;
   margin-bottom: 0.75rem;
+}
+
+.eccn-node.active .node-body {
+  border-left-color: rgba(37, 99, 235, 0.45);
+}
+
+.eccn-node.active-path .node-body {
+  border-left-color: rgba(37, 99, 235, 0.35);
 }
 
 .content {

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -443,6 +443,33 @@ body {
   line-height: 1.6;
 }
 
+.eccn-reference-link,
+.eccn-reference-button {
+  color: #2563eb;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.eccn-reference-button {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+}
+
+.eccn-reference-link:hover,
+.eccn-reference-link:focus-visible,
+.eccn-reference-button:hover,
+.eccn-reference-button:focus-visible {
+  text-decoration: none;
+}
+
+.eccn-reference-button:focus-visible {
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.4);
+  border-radius: 0.2rem;
+  outline: none;
+}
+
 .content-note,
 .content-ednote {
   padding: 0.75rem;

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -669,7 +669,7 @@ function App() {
                             </div>
                           </dl>
                         </header>
-                        <EccnNodeView node={activeEccn.structure} />
+                        <EccnNodeView node={activeEccn.structure} onSelectEccn={handleSelectEccn} />
                       </article>
                     ) : (
                       <div className="placeholder">No ECCNs match the current filter.</div>

--- a/client/src/components/EccnContentBlock.tsx
+++ b/client/src/components/EccnContentBlock.tsx
@@ -1,0 +1,174 @@
+import { useCallback } from 'react';
+import DOMPurify from 'dompurify';
+import { EccnContentBlock } from '../types';
+
+export const ECCN_REFERENCE_PATTERN = /\b([0-9][A-Z][0-9]{3}(?:\.[A-Z0-9-]+)*)\b/g;
+
+export function createEccnReferencePattern(): RegExp {
+  return new RegExp(ECCN_REFERENCE_PATTERN.source, 'g');
+}
+
+export function linkHtmlEccnReferences(html: string): string {
+  if (!html) {
+    return html;
+  }
+
+  if (typeof document === 'undefined') {
+    return html.replace(createEccnReferencePattern(), (_match, eccn: string) =>
+      `<a href="#" class="eccn-reference-link" data-eccn-reference="${eccn}">${eccn}</a>`
+    );
+  }
+
+  const template = document.createElement('template');
+  template.innerHTML = html;
+
+  const walker = document.createTreeWalker(template.content, NodeFilter.SHOW_TEXT);
+  const textNodes: Text[] = [];
+  while (walker.nextNode()) {
+    textNodes.push(walker.currentNode as Text);
+  }
+
+  textNodes.forEach((textNode) => {
+    const textContent = textNode.textContent;
+    if (!textContent) {
+      return;
+    }
+
+    const matches = [...textContent.matchAll(createEccnReferencePattern())];
+    if (matches.length === 0) {
+      return;
+    }
+
+    const fragments: Array<string | HTMLAnchorElement> = [];
+    let lastIndex = 0;
+
+    matches.forEach((match) => {
+      const [fullMatch, eccn] = match;
+      const startIndex = match.index ?? 0;
+      if (startIndex > lastIndex) {
+        fragments.push(textContent.slice(lastIndex, startIndex));
+      }
+
+      const anchor = document.createElement('a');
+      anchor.textContent = fullMatch;
+      anchor.setAttribute('href', '#');
+      anchor.classList.add('eccn-reference-link');
+      anchor.setAttribute('data-eccn-reference', eccn);
+      fragments.push(anchor);
+
+      lastIndex = startIndex + fullMatch.length;
+    });
+
+    if (lastIndex < textContent.length) {
+      fragments.push(textContent.slice(lastIndex));
+    }
+
+    const parent = textNode.parentNode;
+    if (!parent) {
+      return;
+    }
+
+    fragments.forEach((fragment) => {
+      if (typeof fragment === 'string') {
+        parent.insertBefore(document.createTextNode(fragment), textNode);
+      } else {
+        parent.insertBefore(fragment, textNode);
+      }
+    });
+
+    parent.removeChild(textNode);
+  });
+
+  return template.innerHTML;
+}
+
+interface EccnContentBlockViewProps {
+  entry: EccnContentBlock;
+  onSelectEccn?: (eccn: string) => void;
+  className?: string;
+}
+
+export function EccnContentBlockView({ entry, onSelectEccn, className }: EccnContentBlockViewProps) {
+  if (entry.type === 'text') {
+    const text = entry.text ?? '';
+    const fragments: Array<string | JSX.Element> = [];
+    let lastIndex = 0;
+    const matches = [...text.matchAll(createEccnReferencePattern())];
+
+    matches.forEach((match, index) => {
+      const [fullMatch, eccn] = match;
+      const startIndex = match.index ?? 0;
+      if (startIndex > lastIndex) {
+        fragments.push(text.slice(lastIndex, startIndex));
+      }
+
+      fragments.push(
+        <button
+          type="button"
+          className="eccn-reference-button"
+          onClick={() => onSelectEccn?.(eccn)}
+          key={`text-ref-${eccn}-${index}`}
+        >
+          {fullMatch}
+        </button>
+      );
+
+      lastIndex = startIndex + fullMatch.length;
+    });
+
+    if (lastIndex < text.length) {
+      fragments.push(text.slice(lastIndex));
+    }
+
+    if (fragments.length === 0) {
+      fragments.push(text);
+    }
+
+    const mergedClassName = ['content', 'text-only', className].filter(Boolean).join(' ');
+
+    return <p className={mergedClassName}>{fragments}</p>;
+  }
+
+  const sanitizedHtml = entry.html
+    ? DOMPurify.sanitize(entry.html, { USE_PROFILES: { html: true } })
+    : entry.text;
+
+  if (!sanitizedHtml) {
+    return null;
+  }
+
+  const entryClass = `content content-${(entry.tag || 'html').toLowerCase()}`;
+  const mergedClassName = [entryClass, className].filter(Boolean).join(' ');
+  const linkedHtml = linkHtmlEccnReferences(sanitizedHtml);
+
+  const handleClick = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (!onSelectEccn) {
+        return;
+      }
+
+      const target = event.target as HTMLElement | null;
+      const anchor = target?.closest('[data-eccn-reference]') as HTMLElement | null;
+      if (!anchor) {
+        return;
+      }
+
+      const eccn = anchor.getAttribute('data-eccn-reference');
+      if (!eccn) {
+        return;
+      }
+
+      event.preventDefault();
+      onSelectEccn(eccn);
+    },
+    [onSelectEccn]
+  );
+
+  return (
+    <div
+      className={mergedClassName}
+      onClick={handleClick}
+      dangerouslySetInnerHTML={{ __html: linkedHtml }}
+    />
+  );
+}

--- a/client/src/components/EccnNodeView.tsx
+++ b/client/src/components/EccnNodeView.tsx
@@ -1,30 +1,35 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import DOMPurify from 'dompurify';
-import { EccnContentBlock, EccnNode } from '../types';
+import { useEffect, useMemo, useState } from 'react';
+import { EccnNode } from '../types';
+import { EccnContentBlockView } from './EccnContentBlock';
 
 interface EccnNodeViewProps {
   node: EccnNode;
   level?: number;
   onSelectEccn?: (eccn: string) => void;
+  activeNode?: EccnNode;
+  activePath?: Set<EccnNode>;
 }
 
-const ECCN_REFERENCE_PATTERN = /\b([0-9][A-Z][0-9]{3}(?:\.[A-Z0-9-]+)*)\b/g;
-
-function createEccnReferencePattern(): RegExp {
-  return new RegExp(ECCN_REFERENCE_PATTERN.source, 'g');
-}
-
-export function EccnNodeView({ node, level = 0, onSelectEccn }: EccnNodeViewProps) {
+export function EccnNodeView({
+  node,
+  level = 0,
+  onSelectEccn,
+  activeNode,
+  activePath,
+}: EccnNodeViewProps) {
   const isRootEccn = Boolean(node.isEccn && level === 0);
   const isAccordion = Boolean(node.isEccn && !node.boundToParent && !isRootEccn);
-  const [open, setOpen] = useState(() => (isAccordion ? level < 2 : true));
+  const isActive = activeNode === node;
+  const isInActivePath = activePath?.has(node) ?? false;
+  const shouldForceOpen = isAccordion ? level < 2 || isInActivePath : true;
+  const [open, setOpen] = useState(() => shouldForceOpen);
 
   useEffect(() => {
-    setOpen(isAccordion ? level < 2 : true);
-  }, [isAccordion, level, node.identifier]);
+    setOpen(shouldForceOpen);
+  }, [shouldForceOpen]);
 
   const labelText = useMemo(() => {
-    const parts = [] as string[];
+    const parts: string[] = [];
     if (node.identifier) parts.push(node.identifier);
     if (node.heading && node.heading !== node.identifier) parts.push(node.heading);
     if (!parts.length && node.label) parts.push(node.label);
@@ -60,9 +65,20 @@ export function EccnNodeView({ node, level = 0, onSelectEccn }: EccnNodeViewProp
 
   const showLabel = !node.boundToParent;
 
+  const containerClasses = useMemo(() => {
+    const classes = ['eccn-node', `level-${level}`, !isAccordion ? 'static' : ''];
+    if (isActive) {
+      classes.push('active');
+    }
+    if (isInActivePath && !isActive) {
+      classes.push('active-path');
+    }
+    return classes.filter(Boolean).join(' ');
+  }, [isAccordion, isActive, isInActivePath, level]);
+
   if (!isAccordion) {
     return (
-      <div className={`eccn-node level-${level} static`} id={anchorId}>
+      <div className={containerClasses} id={anchorId}>
         {showLabel ? (
           <div className="node-label" aria-label={labelText} title={labelText}>
             {labelIdentifier ? <span className="node-identifier">{labelIdentifier}</span> : null}
@@ -74,7 +90,7 @@ export function EccnNodeView({ node, level = 0, onSelectEccn }: EccnNodeViewProp
         ) : null}
         <div className="node-body">
           {node.content?.map((entry, index) => (
-            <ContentBlock
+            <EccnContentBlockView
               entry={entry}
               key={`${anchorId || labelText}-content-${index}`}
               onSelectEccn={onSelectEccn}
@@ -86,6 +102,8 @@ export function EccnNodeView({ node, level = 0, onSelectEccn }: EccnNodeViewProp
               level={level + 1}
               key={`${anchorId || labelText}-child-${index}`}
               onSelectEccn={onSelectEccn}
+              activeNode={activeNode}
+              activePath={activePath}
             />
           ))}
         </div>
@@ -95,7 +113,7 @@ export function EccnNodeView({ node, level = 0, onSelectEccn }: EccnNodeViewProp
 
   return (
     <details
-      className={`eccn-node level-${level}`}
+      className={containerClasses}
       open={open}
       onToggle={(event) => setOpen((event.currentTarget as HTMLDetailsElement).open)}
       id={anchorId}
@@ -111,7 +129,7 @@ export function EccnNodeView({ node, level = 0, onSelectEccn }: EccnNodeViewProp
       </summary>
       <div className="node-body">
         {node.content?.map((entry, index) => (
-          <ContentBlock
+          <EccnContentBlockView
             entry={entry}
             key={`${anchorId || labelText}-content-${index}`}
             onSelectEccn={onSelectEccn}
@@ -123,165 +141,11 @@ export function EccnNodeView({ node, level = 0, onSelectEccn }: EccnNodeViewProp
             level={level + 1}
             key={`${anchorId || labelText}-child-${index}`}
             onSelectEccn={onSelectEccn}
+            activeNode={activeNode}
+            activePath={activePath}
           />
         ))}
       </div>
     </details>
-  );
-}
-
-function linkHtmlEccnReferences(html: string): string {
-  if (!html) {
-    return html;
-  }
-
-  if (typeof document === 'undefined') {
-    return html.replace(createEccnReferencePattern(), (_match, eccn: string) =>
-      `<a href="#" class="eccn-reference-link" data-eccn-reference="${eccn}">${eccn}</a>`
-    );
-  }
-
-  const template = document.createElement('template');
-  template.innerHTML = html;
-
-  const walker = document.createTreeWalker(template.content, NodeFilter.SHOW_TEXT);
-  const textNodes: Text[] = [];
-  while (walker.nextNode()) {
-    textNodes.push(walker.currentNode as Text);
-  }
-
-  textNodes.forEach((textNode) => {
-    const textContent = textNode.textContent;
-    if (!textContent) {
-      return;
-    }
-
-    const matches = [...textContent.matchAll(createEccnReferencePattern())];
-    if (matches.length === 0) {
-      return;
-    }
-
-    const fragments: Array<string | HTMLAnchorElement> = [];
-    let lastIndex = 0;
-
-    matches.forEach((match) => {
-      const [fullMatch, eccn] = match;
-      const startIndex = match.index ?? 0;
-      if (startIndex > lastIndex) {
-        fragments.push(textContent.slice(lastIndex, startIndex));
-      }
-
-      const anchor = document.createElement('a');
-      anchor.textContent = fullMatch;
-      anchor.setAttribute('href', '#');
-      anchor.classList.add('eccn-reference-link');
-      anchor.setAttribute('data-eccn-reference', eccn);
-      fragments.push(anchor);
-
-      lastIndex = startIndex + fullMatch.length;
-    });
-
-    if (lastIndex < textContent.length) {
-      fragments.push(textContent.slice(lastIndex));
-    }
-
-    const parent = textNode.parentNode;
-    if (!parent) {
-      return;
-    }
-
-    fragments.forEach((fragment) => {
-      if (typeof fragment === 'string') {
-        parent.insertBefore(document.createTextNode(fragment), textNode);
-      } else {
-        parent.insertBefore(fragment, textNode);
-      }
-    });
-
-    parent.removeChild(textNode);
-  });
-
-  return template.innerHTML;
-}
-
-function ContentBlock({ entry, onSelectEccn }: { entry: EccnContentBlock; onSelectEccn?: (eccn: string) => void }) {
-  if (entry.type === 'text') {
-    const text = entry.text ?? '';
-    const fragments: Array<string | JSX.Element> = [];
-    let lastIndex = 0;
-    const matches = [...text.matchAll(createEccnReferencePattern())];
-
-    matches.forEach((match, index) => {
-      const [fullMatch, eccn] = match;
-      const startIndex = match.index ?? 0;
-      if (startIndex > lastIndex) {
-        fragments.push(text.slice(lastIndex, startIndex));
-      }
-
-      fragments.push(
-        <button
-          type="button"
-          className="eccn-reference-button"
-          onClick={() => onSelectEccn?.(eccn)}
-          key={`text-ref-${eccn}-${index}`}
-        >
-          {fullMatch}
-        </button>
-      );
-
-      lastIndex = startIndex + fullMatch.length;
-    });
-
-    if (lastIndex < text.length) {
-      fragments.push(text.slice(lastIndex));
-    }
-
-    if (fragments.length === 0) {
-      fragments.push(text);
-    }
-
-    return <p className="content text-only">{fragments}</p>;
-  }
-
-  const sanitizedHtml = entry.html
-    ? DOMPurify.sanitize(entry.html, { USE_PROFILES: { html: true } })
-    : entry.text;
-
-  if (!sanitizedHtml) {
-    return null;
-  }
-
-  const className = `content content-${(entry.tag || 'html').toLowerCase()}`;
-  const linkedHtml = linkHtmlEccnReferences(sanitizedHtml);
-
-  const handleClick = useCallback(
-    (event: React.MouseEvent<HTMLDivElement>) => {
-      if (!onSelectEccn) {
-        return;
-      }
-
-      const target = event.target as HTMLElement | null;
-      const anchor = target?.closest('[data-eccn-reference]') as HTMLElement | null;
-      if (!anchor) {
-        return;
-      }
-
-      const eccn = anchor.getAttribute('data-eccn-reference');
-      if (!eccn) {
-        return;
-      }
-
-      event.preventDefault();
-      onSelectEccn(eccn);
-    },
-    [onSelectEccn]
-  );
-
-  return (
-    <div
-      className={className}
-      onClick={handleClick}
-      dangerouslySetInnerHTML={{ __html: linkedHtml }}
-    />
   );
 }

--- a/client/src/components/EccnNodeView.tsx
+++ b/client/src/components/EccnNodeView.tsx
@@ -1,14 +1,22 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import DOMPurify from 'dompurify';
 import { EccnContentBlock, EccnNode } from '../types';
 
 interface EccnNodeViewProps {
   node: EccnNode;
   level?: number;
+  onSelectEccn?: (eccn: string) => void;
 }
 
-export function EccnNodeView({ node, level = 0 }: EccnNodeViewProps) {
-  const isAccordion = Boolean(node.isEccn && !node.boundToParent);
+const ECCN_REFERENCE_PATTERN = /\b([0-9][A-Z][0-9]{3}(?:\.[A-Z0-9-]+)*)\b/g;
+
+function createEccnReferencePattern(): RegExp {
+  return new RegExp(ECCN_REFERENCE_PATTERN.source, 'g');
+}
+
+export function EccnNodeView({ node, level = 0, onSelectEccn }: EccnNodeViewProps) {
+  const isRootEccn = Boolean(node.isEccn && level === 0);
+  const isAccordion = Boolean(node.isEccn && !node.boundToParent && !isRootEccn);
   const [open, setOpen] = useState(() => (isAccordion ? level < 2 : true));
 
   useEffect(() => {
@@ -66,10 +74,19 @@ export function EccnNodeView({ node, level = 0 }: EccnNodeViewProps) {
         ) : null}
         <div className="node-body">
           {node.content?.map((entry, index) => (
-            <ContentBlock entry={entry} key={`${anchorId || labelText}-content-${index}`} />
+            <ContentBlock
+              entry={entry}
+              key={`${anchorId || labelText}-content-${index}`}
+              onSelectEccn={onSelectEccn}
+            />
           ))}
           {node.children?.map((child, index) => (
-            <EccnNodeView node={child} level={level + 1} key={`${anchorId || labelText}-child-${index}`} />
+            <EccnNodeView
+              node={child}
+              level={level + 1}
+              key={`${anchorId || labelText}-child-${index}`}
+              onSelectEccn={onSelectEccn}
+            />
           ))}
         </div>
       </div>
@@ -94,19 +111,136 @@ export function EccnNodeView({ node, level = 0 }: EccnNodeViewProps) {
       </summary>
       <div className="node-body">
         {node.content?.map((entry, index) => (
-          <ContentBlock entry={entry} key={`${anchorId || labelText}-content-${index}`} />
+          <ContentBlock
+            entry={entry}
+            key={`${anchorId || labelText}-content-${index}`}
+            onSelectEccn={onSelectEccn}
+          />
         ))}
         {node.children?.map((child, index) => (
-          <EccnNodeView node={child} level={level + 1} key={`${anchorId || labelText}-child-${index}`} />
+          <EccnNodeView
+            node={child}
+            level={level + 1}
+            key={`${anchorId || labelText}-child-${index}`}
+            onSelectEccn={onSelectEccn}
+          />
         ))}
       </div>
     </details>
   );
 }
 
-function ContentBlock({ entry }: { entry: EccnContentBlock }) {
+function linkHtmlEccnReferences(html: string): string {
+  if (!html) {
+    return html;
+  }
+
+  if (typeof document === 'undefined') {
+    return html.replace(createEccnReferencePattern(), (_match, eccn: string) =>
+      `<a href="#" class="eccn-reference-link" data-eccn-reference="${eccn}">${eccn}</a>`
+    );
+  }
+
+  const template = document.createElement('template');
+  template.innerHTML = html;
+
+  const walker = document.createTreeWalker(template.content, NodeFilter.SHOW_TEXT);
+  const textNodes: Text[] = [];
+  while (walker.nextNode()) {
+    textNodes.push(walker.currentNode as Text);
+  }
+
+  textNodes.forEach((textNode) => {
+    const textContent = textNode.textContent;
+    if (!textContent) {
+      return;
+    }
+
+    const matches = [...textContent.matchAll(createEccnReferencePattern())];
+    if (matches.length === 0) {
+      return;
+    }
+
+    const fragments: Array<string | HTMLAnchorElement> = [];
+    let lastIndex = 0;
+
+    matches.forEach((match) => {
+      const [fullMatch, eccn] = match;
+      const startIndex = match.index ?? 0;
+      if (startIndex > lastIndex) {
+        fragments.push(textContent.slice(lastIndex, startIndex));
+      }
+
+      const anchor = document.createElement('a');
+      anchor.textContent = fullMatch;
+      anchor.setAttribute('href', '#');
+      anchor.classList.add('eccn-reference-link');
+      anchor.setAttribute('data-eccn-reference', eccn);
+      fragments.push(anchor);
+
+      lastIndex = startIndex + fullMatch.length;
+    });
+
+    if (lastIndex < textContent.length) {
+      fragments.push(textContent.slice(lastIndex));
+    }
+
+    const parent = textNode.parentNode;
+    if (!parent) {
+      return;
+    }
+
+    fragments.forEach((fragment) => {
+      if (typeof fragment === 'string') {
+        parent.insertBefore(document.createTextNode(fragment), textNode);
+      } else {
+        parent.insertBefore(fragment, textNode);
+      }
+    });
+
+    parent.removeChild(textNode);
+  });
+
+  return template.innerHTML;
+}
+
+function ContentBlock({ entry, onSelectEccn }: { entry: EccnContentBlock; onSelectEccn?: (eccn: string) => void }) {
   if (entry.type === 'text') {
-    return <p className="content text-only">{entry.text}</p>;
+    const text = entry.text ?? '';
+    const fragments: Array<string | JSX.Element> = [];
+    let lastIndex = 0;
+    const matches = [...text.matchAll(createEccnReferencePattern())];
+
+    matches.forEach((match, index) => {
+      const [fullMatch, eccn] = match;
+      const startIndex = match.index ?? 0;
+      if (startIndex > lastIndex) {
+        fragments.push(text.slice(lastIndex, startIndex));
+      }
+
+      fragments.push(
+        <button
+          type="button"
+          className="eccn-reference-button"
+          onClick={() => onSelectEccn?.(eccn)}
+          key={`text-ref-${eccn}-${index}`}
+        >
+          {fullMatch}
+        </button>
+      );
+
+      lastIndex = startIndex + fullMatch.length;
+    });
+
+    if (lastIndex < text.length) {
+      fragments.push(text.slice(lastIndex));
+    }
+
+    if (fragments.length === 0) {
+      fragments.push(text);
+    }
+
+    return <p className="content text-only">{fragments}</p>;
   }
 
   const sanitizedHtml = entry.html
@@ -118,6 +252,36 @@ function ContentBlock({ entry }: { entry: EccnContentBlock }) {
   }
 
   const className = `content content-${(entry.tag || 'html').toLowerCase()}`;
+  const linkedHtml = linkHtmlEccnReferences(sanitizedHtml);
 
-  return <div className={className} dangerouslySetInnerHTML={{ __html: sanitizedHtml }} />;
+  const handleClick = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (!onSelectEccn) {
+        return;
+      }
+
+      const target = event.target as HTMLElement | null;
+      const anchor = target?.closest('[data-eccn-reference]') as HTMLElement | null;
+      if (!anchor) {
+        return;
+      }
+
+      const eccn = anchor.getAttribute('data-eccn-reference');
+      if (!eccn) {
+        return;
+      }
+
+      event.preventDefault();
+      onSelectEccn(eccn);
+    },
+    [onSelectEccn]
+  );
+
+  return (
+    <div
+      className={className}
+      onClick={handleClick}
+      dangerouslySetInnerHTML={{ __html: linkedHtml }}
+    />
+  );
 }


### PR DESCRIPTION
## Summary
- render the selected ECCN details directly in the main content instead of wrapping them in an accordion
- add detection of ECCN references inside content blocks and turn them into clickable links that trigger navigation
- style the new ECCN reference links to look and behave like interactive elements

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbe0a151d4832f870b3ee38eb234b1