### PR TITLE
Parse license exceptions and render structured table

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -203,6 +203,39 @@ body {
   color: #4b5563;
 }
 
+.code-chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  align-items: center;
+}
+
+.code-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid #d1d5db;
+  background: #f3f4f6;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #1f2937;
+  cursor: help;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.code-chip:hover,
+.code-chip:focus {
+  background: #e0e7ff;
+  border-color: #6366f1;
+  color: #312e81;
+}
+
+.license-exception-table .code-chip {
+  margin: 0 auto;
+}
+
 .version-list dt {
   font-weight: 600;
 }


### PR DESCRIPTION
## Summary
- detect list-based license exception sections even when the heading is omitted by scanning for exception code tokens
- parse the collected license exception blocks into structured entries and render them as a two-column table in the ECCN detail view

## Testing
- npm run build
- node - <<'NODE' ... # parsed example-title-15.xml to verify 3A090 license exception detection


------
https://chatgpt.com/codex/tasks/task_e_68dc4ddc6cbc832fb3e1c322fa2fc563