### PR TITLE
Limit ECCN detail view to child nodes

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -424,6 +424,23 @@ body {
   overflow: hidden;
 }
 
+.eccn-children {
+  margin-top: 1.5rem;
+}
+
+.eccn-children h4 {
+  margin: 0 0 0.75rem;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.eccn-children-tree {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
 .eccn-high-level-row {
   display: grid;
   grid-template-columns: minmax(180px, 220px) 1fr;

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1174,6 +1174,8 @@ function App() {
     return extractHighLevelDetails(activeEccn.structure);
   }, [activeEccn]);
 
+  const eccnChildren = activeEccn?.structure.children ?? [];
+
   const normalizedFocusedIdentifier = useMemo(() => normalizeNodeIdentifier(focusedNodeIdentifier), [focusedNodeIdentifier]);
 
   const { focusedNode, focusedPath } = useMemo<{
@@ -1497,12 +1499,28 @@ function App() {
                             ))}
                           </dl>
                         )}
-                        <EccnNodeView
-                          node={activeEccn.structure}
-                          onSelectEccn={handleSelectEccn}
-                          activeNode={focusedNode}
-                          activePath={focusedPath}
-                        />
+                        <section className="eccn-children">
+                          <h4>ECCN Children</h4>
+                          {eccnChildren.length > 0 ? (
+                            <div className="eccn-children-tree">
+                              {eccnChildren.map((child, index) => {
+                                const key = getNodeAnchorId(child) ?? `eccn-child-${index}`;
+                                return (
+                                  <EccnNodeView
+                                    node={child}
+                                    level={1}
+                                    key={key}
+                                    onSelectEccn={handleSelectEccn}
+                                    activeNode={focusedNode}
+                                    activePath={focusedPath}
+                                  />
+                                );
+                              })}
+                            </div>
+                          ) : (
+                            <p className="help-text">This ECCN does not have any child entries.</p>
+                          )}
+                        </section>
                       </article>
                     ) : (
                       <div className="placeholder">No ECCNs match the current filter.</div>


### PR DESCRIPTION
## Summary
- update the ECCN detail pane to hide the parent node content and render only the hierarchical children under an "ECCN Children" heading
- add supporting layout styles so the new children section integrates with the existing design

## Testing
- npm run build --prefix client
- CCL_SKIP_SERVER=true node --input-type=module - <<'NODE'
import { readFile } from 'node:fs/promises';
import { parsePart } from './server/index.js';

const xml = await readFile(new URL('./example-title-15.xml', import.meta.url), 'utf8');
const { supplements } = parsePart(xml);
console.log('Supplements:', supplements.map((entry) => `${entry.number}:${entry.heading}`));
const supplementOne = supplements.find((entry) => entry.number === '1');
if (supplementOne) {
  const firstWithChildren = supplementOne.eccns.find((entry) => (entry.structure.children?.length ?? 0) > 0);
  if (firstWithChildren) {
    console.log(`ECCN ${firstWithChildren.eccn} has ${firstWithChildren.structure.children?.length ?? 0} direct children.`);
  } else {
    console.log('No ECCN in Supplement No. 1 has child nodes in the sample data.');
  }
} else {
  console.log('Supplement No. 1 not found.');
}
NODE

------
https://chatgpt.com/codex/tasks/task_e_68dc585647dc832fbaf6fea123fe3a62