### PR TITLE
Highlight linked ECCNs in ECCN detail view

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -416,6 +416,81 @@ body {
   color: #4b5563;
 }
 
+.linked-eccn-list {
+  margin: 0.35rem 0 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.linked-eccn-list li {
+  margin: 0;
+  padding: 0;
+}
+
+.linked-eccn-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(37, 99, 235, 0.28);
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+  padding: 0.35rem 0.7rem;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  min-height: 2.1rem;
+}
+
+.linked-eccn-link .linked-eccn-code {
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+}
+
+.linked-eccn-link .linked-eccn-label {
+  color: #1f2937;
+  font-weight: 500;
+  font-size: 0.85rem;
+  white-space: normal;
+  line-height: 1.25;
+}
+
+.linked-eccn-link .linked-eccn-count {
+  background: rgba(37, 99, 235, 0.22);
+  color: #1d4ed8;
+  border-radius: 999px;
+  padding: 0 0.4rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.linked-eccn-link:hover,
+.linked-eccn-link:focus-visible {
+  background: rgba(37, 99, 235, 0.18);
+  border-color: #2563eb;
+}
+
+.linked-eccn-link:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}
+
+.linked-eccn-link.missing {
+  border-color: rgba(107, 114, 128, 0.45);
+  background: rgba(107, 114, 128, 0.16);
+  color: #374151;
+}
+
+.linked-eccn-link.missing .linked-eccn-count {
+  background: rgba(107, 114, 128, 0.3);
+  color: #1f2937;
+}
+
 .eccn-high-level {
   margin: 1.5rem 0;
   border: 1px solid #e5e7eb;

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -12,7 +12,7 @@ import {
 } from './types';
 import { VersionControls } from './components/VersionControls';
 import { EccnNodeView } from './components/EccnNodeView';
-import { EccnContentBlockView } from './components/EccnContentBlock';
+import { EccnContentBlockView, createEccnReferencePattern } from './components/EccnContentBlock';
 import { formatDateTime, formatNumber } from './utils/format';
 
 const ECCN_BASE_PATTERN = /^[0-9][A-Z][0-9]{3}$/;
@@ -209,6 +209,14 @@ interface HighLevelField {
   blocks: EccnContentBlock[];
 }
 
+interface LinkedEccnSummary {
+  code: string;
+  baseCode: string;
+  count: number;
+  exists: boolean;
+  label?: string | null;
+}
+
 const SANITIZE_ANCHOR_PATTERN = /[^\w.-]+/g;
 const CONTROL_HEADING_PATTERN = /control(?:s)?\s+(?:country\s+chart|table)/i;
 
@@ -238,6 +246,50 @@ function getBlockPlainText(block: EccnContentBlock): string {
     return stripHtmlTags(block.html);
   }
   return '';
+}
+
+function accumulateEccnReferencesFromText(
+  value: string | null | undefined,
+  accumulator: Map<string, number>
+) {
+  if (!value) {
+    return;
+  }
+
+  const regex = createEccnReferencePattern();
+  let match: RegExpExecArray | null = regex.exec(value);
+
+  while (match) {
+    const eccn = match[1];
+    if (eccn) {
+      const normalized = eccn.toUpperCase();
+      const current = accumulator.get(normalized) ?? 0;
+      accumulator.set(normalized, current + 1);
+    }
+    match = regex.exec(value);
+  }
+}
+
+function collectLinkedEccnReferences(
+  node: EccnNode | undefined,
+  accumulator: Map<string, number>
+): Map<string, number> {
+  if (!node) {
+    return accumulator;
+  }
+
+  if (node.content) {
+    node.content.forEach((block) => {
+      accumulateEccnReferencesFromText(block.text ?? null, accumulator);
+      accumulateEccnReferencesFromText(block.html ?? null, accumulator);
+    });
+  }
+
+  if (node.children) {
+    node.children.forEach((child) => collectLinkedEccnReferences(child, accumulator));
+  }
+
+  return accumulator;
 }
 
 function collectPrimaryBlocks(node: EccnNode): EccnContentBlock[] {
@@ -1176,6 +1228,54 @@ function App() {
 
   const eccnChildren = activeEccn?.structure.children ?? [];
 
+  const linkedEccns = useMemo<LinkedEccnSummary[]>(() => {
+    if (!activeEccn) {
+      return [];
+    }
+
+    const counts = collectLinkedEccnReferences(activeEccn.structure, new Map<string, number>());
+    if (counts.size === 0) {
+      return [];
+    }
+
+    const normalizedActive = activeEccn.eccn.trim().toUpperCase();
+    const summaries: LinkedEccnSummary[] = [];
+
+    counts.forEach((count, code) => {
+      const parsed = parseNormalizedEccn(code);
+      const baseCode = parsed?.segments?.[0]?.raw?.toUpperCase() ?? code;
+      if (baseCode === normalizedActive) {
+        return;
+      }
+
+      const baseEntry = eccnLookup.get(baseCode);
+      const exactEntry = eccnLookup.get(code) ?? baseEntry;
+
+      summaries.push({
+        code,
+        baseCode,
+        count,
+        exists: Boolean(baseEntry),
+        label: exactEntry?.title ?? exactEntry?.heading ?? null,
+      });
+    });
+
+    summaries.sort((a, b) => {
+      if (b.count !== a.count) {
+        return b.count - a.count;
+      }
+      if (a.exists !== b.exists) {
+        return Number(b.exists) - Number(a.exists);
+      }
+      if (a.baseCode !== b.baseCode) {
+        return a.baseCode.localeCompare(b.baseCode);
+      }
+      return a.code.localeCompare(b.code);
+    });
+
+    return summaries;
+  }, [activeEccn, eccnLookup]);
+
   const normalizedFocusedIdentifier = useMemo(() => normalizeNodeIdentifier(focusedNodeIdentifier), [focusedNodeIdentifier]);
 
   const { focusedNode, focusedPath } = useMemo<{
@@ -1476,6 +1576,64 @@ function App() {
                                 {activeEccn.childEccns && activeEccn.childEccns.length > 0
                                   ? activeEccn.childEccns.join(', ')
                                   : '–'}
+                              </dd>
+                            </div>
+                            <div>
+                              <dt>Linked ECCNs</dt>
+                              <dd>
+                                {linkedEccns.length > 0 ? (
+                                  <ul className="linked-eccn-list">
+                                    {linkedEccns.map((linked) => {
+                                      const ariaDescriptionParts: string[] = [`View ECCN ${linked.code}`];
+                                      if (linked.label) {
+                                        ariaDescriptionParts.push(linked.label);
+                                      }
+                                      if (!linked.exists) {
+                                        ariaDescriptionParts.push('Not present in selected dataset');
+                                      }
+                                      if (linked.count > 1) {
+                                        ariaDescriptionParts.push(`Referenced ${linked.count} times`);
+                                      }
+                                      const ariaLabel = ariaDescriptionParts.join(' – ');
+                                      const tooltipParts: string[] = [];
+                                      if (linked.label) {
+                                        tooltipParts.push(linked.label);
+                                      }
+                                      if (linked.count > 1) {
+                                        tooltipParts.push(`Referenced ${linked.count} times`);
+                                      }
+                                      const title = tooltipParts.length > 0 ? tooltipParts.join(' • ') : undefined;
+
+                                      const buttonClassName = ['linked-eccn-link', linked.exists ? '' : 'missing']
+                                        .filter(Boolean)
+                                        .join(' ');
+
+                                      return (
+                                        <li key={linked.code}>
+                                          <button
+                                            type="button"
+                                            className={buttonClassName}
+                                            onClick={() => handleSelectEccn(linked.code)}
+                                            aria-label={ariaLabel}
+                                            title={title}
+                                          >
+                                            <span className="linked-eccn-code">{linked.code}</span>
+                                            {linked.label ? (
+                                              <span className="linked-eccn-label">{linked.label}</span>
+                                            ) : null}
+                                            {linked.count > 1 ? (
+                                              <span className="linked-eccn-count" aria-hidden="true">
+                                                ×{linked.count}
+                                              </span>
+                                            ) : null}
+                                          </button>
+                                        </li>
+                                      );
+                                    })}
+                                  </ul>
+                                ) : (
+                                  '–'
+                                )}
                               </dd>
                             </div>
                           </dl>


### PR DESCRIPTION
## Summary
- collect ECCN references from the active ECCN content tree and derive a linked ECCN summary
- render the linked ECCNs in the detail header with interactive styling so users can navigate between related entries
- add styling for linked ECCN badges that adapts when the target entry is missing from the current dataset

## Testing
- npm run build --prefix client
- node -e "process.env.CCL_SKIP_SERVER='true'; import('./server/index.js').then(async ({ parsePart }) => { const fs = await import('fs/promises'); const xml = await fs.readFile('example-title-15.xml', 'utf-8'); const result = parsePart(xml); console.log('Supplements parsed:', result.supplements.length); console.log('Sample ECCNs:', result.supplements.flatMap((supplement) => supplement.eccns.map((entry) => entry.eccn)).slice(0, 5).join(', ')); }).catch((error) => { console.error(error); process.exit(1); });"

------
https://chatgpt.com/codex/tasks/task_e_68dc6c8d9f84832fbc3d9601c38a2661