### PR TITLE
Clarify ECCN child accordion affordances

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -518,6 +518,32 @@ body {
   color: #1f2937;
 }
 
+.eccn-node.accordion summary {
+  position: relative;
+  padding-left: 1.35rem;
+}
+
+.eccn-node.accordion summary::marker,
+.eccn-node.accordion summary::-webkit-details-marker {
+  display: none;
+}
+
+.eccn-node.accordion summary::before {
+  content: '▸';
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  color: #2563eb;
+  transition: transform 0.2s ease;
+  font-size: 0.85rem;
+  line-height: 1;
+}
+
+.eccn-node.accordion.has-details[open] summary::before {
+  transform: translateY(-50%) rotate(90deg);
+}
+
 .eccn-node .node-label {
   display: inline-flex;
   align-items: center;
@@ -525,6 +551,32 @@ body {
   flex-wrap: wrap;
   font-weight: 600;
   color: #1f2937;
+}
+
+.eccn-node.accordion.no-details .node-label {
+  position: relative;
+  padding-left: 1.35rem;
+  color: #6b7280;
+}
+
+.eccn-node.accordion.no-details .node-label::before {
+  content: '–';
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  color: #9ca3af;
+  font-weight: 600;
+}
+
+.eccn-node.accordion.no-details .node-label[aria-disabled='true'] {
+  cursor: default;
+}
+
+.eccn-node.accordion.no-details .node-identifier {
+  border-color: rgba(107, 114, 128, 0.45);
+  background: rgba(107, 114, 128, 0.16);
+  color: #4b5563;
 }
 
 .eccn-node.active .node-label {

--- a/client/src/components/EccnNodeView.tsx
+++ b/client/src/components/EccnNodeView.tsx
@@ -19,9 +19,11 @@ export function EccnNodeView({
 }: EccnNodeViewProps) {
   const isRootEccn = Boolean(node.isEccn && level === 0);
   const isAccordion = Boolean(node.isEccn && !node.boundToParent && !isRootEccn);
+  const hasDetails = Boolean((node.content?.length ?? 0) > 0 || (node.children?.length ?? 0) > 0);
+  const isCollapsible = isAccordion && hasDetails;
   const isActive = activeNode === node;
   const isInActivePath = activePath?.has(node) ?? false;
-  const shouldForceOpen = isAccordion ? level < 2 || isInActivePath : true;
+  const shouldForceOpen = isCollapsible ? level < 2 || isInActivePath : true;
   const [open, setOpen] = useState(() => shouldForceOpen);
 
   useEffect(() => {
@@ -66,7 +68,14 @@ export function EccnNodeView({
   const showLabel = !node.boundToParent;
 
   const containerClasses = useMemo(() => {
-    const classes = ['eccn-node', `level-${level}`, !isAccordion ? 'static' : ''];
+    const classes = ['eccn-node', `level-${level}`];
+    if (isCollapsible) {
+      classes.push('accordion', 'has-details');
+    } else if (isAccordion) {
+      classes.push('accordion', 'no-details');
+    } else {
+      classes.push('static');
+    }
     if (isActive) {
       classes.push('active');
     }
@@ -74,13 +83,18 @@ export function EccnNodeView({
       classes.push('active-path');
     }
     return classes.filter(Boolean).join(' ');
-  }, [isAccordion, isActive, isInActivePath, level]);
+  }, [isAccordion, isActive, isInActivePath, isCollapsible, level]);
 
-  if (!isAccordion) {
+  if (!isCollapsible) {
     return (
       <div className={containerClasses} id={anchorId}>
         {showLabel ? (
-          <div className="node-label" aria-label={labelText} title={labelText}>
+          <div
+            className="node-label"
+            aria-label={labelText}
+            title={labelText}
+            aria-disabled={isAccordion && !hasDetails ? true : undefined}
+          >
             {labelIdentifier ? <span className="node-identifier">{labelIdentifier}</span> : null}
             {labelHeading ? <span className="node-heading">{labelHeading}</span> : null}
             {!labelIdentifier && !labelHeading ? (


### PR DESCRIPTION
## Summary
- treat ECCN child nodes without content as non-collapsible while exposing their state for styling
- add classes and aria flags so the UI can distinguish between children with additional details and those without
- introduce chevron indicators and muted styling to clearly communicate which accordion entries can expand

## Testing
- npm run build --prefix client
- CCL_SKIP_SERVER=true node --input-type=module - <<'NODE' … (parse example-title-15.xml)


------
https://chatgpt.com/codex/tasks/task_e_68dc95461578832f812c05cb6806b2b3