### PR TITLE
Add settings tab for managing CCL data actions

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -92,6 +92,15 @@ body {
   min-height: 0;
 }
 
+.settings-layout {
+  flex: 1;
+  display: grid;
+  grid-template-columns: minmax(280px, 360px) 1fr;
+  gap: 1.5rem;
+  min-height: 0;
+  align-items: start;
+}
+
 .sidebar {
   display: flex;
   flex-direction: column;
@@ -1483,6 +1492,10 @@ body {
   }
 
   .history-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-layout {
     grid-template-columns: 1fr;
   }
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,6 +11,7 @@ import {
   VersionsResponse,
 } from './types';
 import { VersionControls } from './components/VersionControls';
+import { VersionSettings } from './components/VersionSettings';
 import { EccnNodeView } from './components/EccnNodeView';
 import { EccnContentBlockView } from './components/EccnContentBlock';
 import { TradeDataView } from './components/TradeDataView';
@@ -944,7 +945,7 @@ function App() {
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [eccnPreview, setEccnPreview] = useState<EccnPreviewState | null>(null);
-  const [activeTab, setActiveTab] = useState<'explorer' | 'history' | 'trade'>('explorer');
+  const [activeTab, setActiveTab] = useState<'explorer' | 'history' | 'trade' | 'settings'>('explorer');
   const [showScrollTop, setShowScrollTop] = useState(false);
   const skipNextLoad = useRef(false);
   const previewCardRef = useRef<HTMLDivElement | null>(null);
@@ -1634,6 +1635,15 @@ function App() {
           >
             Trade Data by ECCN
           </button>
+          <button
+            type="button"
+            className="app-tab-button"
+            data-active={activeTab === 'settings'}
+            onClick={() => setActiveTab('settings')}
+            aria-current={activeTab === 'settings' ? 'page' : undefined}
+          >
+            Settings
+          </button>
         </nav>
       </header>
       <main className="app-main">
@@ -1645,10 +1655,7 @@ function App() {
                 defaultDate={defaultDate}
                 selectedDate={selectedDate}
                 onSelect={handleSelectVersion}
-                onRefresh={handleRefreshVersion}
-                onLoad={handleLoadNewVersion}
                 loadingVersions={loadingVersions}
-                refreshing={refreshing}
               />
               {error && <div className="alert error">{error}</div>}
             </aside>
@@ -1919,6 +1926,32 @@ function App() {
         {activeTab === 'trade' ? (
           <div className="trade-layout">
             <TradeDataView onNavigateToEccn={handleNavigateToEccn} />
+          </div>
+        ) : null}
+        {activeTab === 'settings' ? (
+          <div className="settings-layout">
+            <VersionSettings
+              defaultDate={defaultDate}
+              selectedDate={selectedDate}
+              onRefresh={handleRefreshVersion}
+              onLoad={handleLoadNewVersion}
+              refreshing={refreshing}
+              error={error}
+            />
+            <section className="panel settings-info">
+              <header className="panel-header">
+                <h2>How data caching works</h2>
+              </header>
+              <p>
+                The Explorer stores downloaded Commerce Control List data in your local browser so you can
+                revisit previously fetched versions without downloading them again. Refreshing replaces the
+                cached copy for the selected date, while "Fetch &amp; store" adds a new version by date.
+              </p>
+              <p className="help-text">
+                Data is loaded from the official eCFR XML source and parsed locally for fast, offline
+                browsing.
+              </p>
+            </section>
           </div>
         ) : null}
       </main>

--- a/client/src/components/EccnHistoryView.tsx
+++ b/client/src/components/EccnHistoryView.tsx
@@ -202,7 +202,7 @@ function determineChangeStatus(
   if (!current && previous) {
     return 'removed';
   }
-  if (!current && !previous) {
+  if (!current || !previous) {
     return 'unchanged';
   }
   return current.text === previous.text ? 'unchanged' : 'changed';

--- a/client/src/components/VersionControls.tsx
+++ b/client/src/components/VersionControls.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FormEvent, useEffect, useMemo, useState } from 'react';
+import { ChangeEvent, useMemo } from 'react';
 import { VersionSummary } from '../types';
 import { formatDate, formatDateTime, formatNumber } from '../utils/format';
 
@@ -7,10 +7,7 @@ interface VersionControlsProps {
   defaultDate?: string;
   selectedDate?: string;
   onSelect: (date: string) => void;
-  onRefresh: (date: string) => Promise<void> | void;
-  onLoad: (date: string) => Promise<void> | void;
   loadingVersions: boolean;
-  refreshing: boolean;
 }
 
 export function VersionControls({
@@ -18,19 +15,8 @@ export function VersionControls({
   defaultDate,
   selectedDate,
   onSelect,
-  onRefresh,
-  onLoad,
   loadingVersions,
-  refreshing,
 }: VersionControlsProps) {
-  const [manualDate, setManualDate] = useState('');
-
-  useEffect(() => {
-    if (selectedDate && !manualDate) {
-      setManualDate(selectedDate);
-    }
-  }, [selectedDate, manualDate]);
-
   const sortedVersions = useMemo(() => {
     return [...versions].sort((a, b) => (a.date < b.date ? 1 : -1));
   }, [versions]);
@@ -39,19 +25,6 @@ export function VersionControls({
     const { value } = event.target;
     if (value) {
       onSelect(value);
-    }
-  };
-
-  const handleRefreshClick = () => {
-    if (selectedDate) {
-      onRefresh(selectedDate);
-    }
-  };
-
-  const handleManualSubmit = (event: FormEvent) => {
-    event.preventDefault();
-    if (manualDate) {
-      onLoad(manualDate);
     }
   };
 
@@ -69,7 +42,7 @@ export function VersionControls({
           className="control"
           value={selectedDate ?? ''}
           onChange={handleSelectChange}
-          disabled={loadingVersions || refreshing || sortedVersions.length === 0}
+          disabled={loadingVersions || sortedVersions.length === 0}
         >
           {sortedVersions.length === 0 && <option value="">No versions cached</option>}
           {sortedVersions.map((version) => (
@@ -78,35 +51,8 @@ export function VersionControls({
             </option>
           ))}
         </select>
-        <button
-          type="button"
-          className="button"
-          onClick={handleRefreshClick}
-          disabled={!selectedDate || refreshing}
-        >
-          {refreshing ? 'Refreshing…' : 'Refresh selected'}
-        </button>
+        <p className="help-text">Select a cached version to explore in the CCL browser.</p>
       </div>
-
-      <form className="control-group" onSubmit={handleManualSubmit}>
-        <label htmlFor="manual-date">Fetch a different version</label>
-        <div className="inline-controls">
-          <input
-            id="manual-date"
-            className="control"
-            type="date"
-            value={manualDate}
-            onChange={(event) => setManualDate(event.target.value)}
-            max={defaultDate}
-          />
-          <button type="submit" className="button primary" disabled={!manualDate || refreshing}>
-            {refreshing ? 'Loading…' : 'Fetch & store'}
-          </button>
-        </div>
-        <p className="help-text">
-          Downloads and parses the selected CCL version, storing it locally for reuse.
-        </p>
-      </form>
 
       {sortedVersions.length > 0 && (
         <div className="control-group">

--- a/client/src/components/VersionSettings.tsx
+++ b/client/src/components/VersionSettings.tsx
@@ -1,0 +1,92 @@
+import { FormEvent, useEffect, useState } from 'react';
+import { formatDate } from '../utils/format';
+
+interface VersionSettingsProps {
+  defaultDate?: string;
+  selectedDate?: string;
+  refreshing: boolean;
+  onRefresh: (date: string) => Promise<void> | void;
+  onLoad: (date: string) => Promise<void> | void;
+  error?: string | null;
+}
+
+export function VersionSettings({
+  defaultDate,
+  selectedDate,
+  refreshing,
+  onRefresh,
+  onLoad,
+  error,
+}: VersionSettingsProps) {
+  const [manualDate, setManualDate] = useState('');
+
+  useEffect(() => {
+    if (selectedDate && !manualDate) {
+      setManualDate(selectedDate);
+    }
+  }, [selectedDate, manualDate]);
+
+  const handleRefreshClick = () => {
+    if (selectedDate) {
+      onRefresh(selectedDate);
+    }
+  };
+
+  const handleManualSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    if (manualDate) {
+      onLoad(manualDate);
+    }
+  };
+
+  const latestDateLabel = defaultDate ? formatDate(defaultDate) : null;
+  const selectedDateLabel = selectedDate ? formatDate(selectedDate) : null;
+
+  return (
+    <section className="panel settings-panel">
+      <header className="panel-header">
+        <h2>CCL Data Settings</h2>
+        {latestDateLabel ? <p className="subtle">Latest available date: {latestDateLabel}</p> : null}
+      </header>
+
+      <div className="control-group">
+        <h3>Refresh stored version</h3>
+        <p className="help-text">
+          {selectedDateLabel
+            ? `Refresh the cached data for the currently selected version (${selectedDateLabel}).`
+            : 'Select a stored version from the explorer to enable refreshing.'}
+        </p>
+        <button
+          type="button"
+          className="button"
+          onClick={handleRefreshClick}
+          disabled={!selectedDate || refreshing}
+        >
+          {refreshing ? 'Refreshing…' : 'Refresh selected version'}
+        </button>
+      </div>
+
+      <form className="control-group" onSubmit={handleManualSubmit}>
+        <h3>Fetch a specific version</h3>
+        <div className="inline-controls">
+          <input
+            id="settings-manual-date"
+            className="control"
+            type="date"
+            value={manualDate}
+            onChange={(event) => setManualDate(event.target.value)}
+            max={defaultDate}
+          />
+          <button type="submit" className="button primary" disabled={!manualDate || refreshing}>
+            {refreshing ? 'Loading…' : 'Fetch & store'}
+          </button>
+        </div>
+        <p className="help-text">
+          Downloads and parses the selected CCL version, storing it locally for offline use.
+        </p>
+      </form>
+
+      {error ? <div className="alert error">{error}</div> : null}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated Settings tab that hosts refresh and fetch controls for CCL data
- simplify the explorer sidebar version controls to focus on stored version selection and details
- tweak layout styling and harden history change detection to satisfy TypeScript checks

## Testing
- npm run build --prefix client
- node --test server/index.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dd92e83bc8832f9e3edaa1aba97cd4