### PR TITLE
Persist tab selection and search queries in URL

### DIFF
--- a/client/src/components/EccnHistoryView.tsx
+++ b/client/src/components/EccnHistoryView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { FormEvent, JSX } from 'react';
 import {
   CclDataset,
@@ -24,6 +24,8 @@ interface EccnHistoryViewProps {
   onNavigateToEccn: (eccn: string) => void;
   query?: string;
   onQueryChange?: (value: string) => void;
+  selectedCode?: string;
+  onSelectedCodeChange?: (value: string) => void;
 }
 
 type HistoryChildDetail = {
@@ -255,9 +257,11 @@ export function EccnHistoryView({
   onNavigateToEccn,
   query: initialQuery = '',
   onQueryChange,
+  selectedCode: externalSelectedCode = '',
+  onSelectedCodeChange,
 }: EccnHistoryViewProps) {
   const [query, setQuery] = useState(initialQuery);
-  const [selectedCode, setSelectedCode] = useState('');
+  const [selectedCode, setSelectedCode] = useState(externalSelectedCode);
   const [historyEntries, setHistoryEntries] = useState<HistoryVersionEntry[]>([]);
   const [loadingHistory, setLoadingHistory] = useState(false);
   const [historyError, setHistoryError] = useState<string | null>(null);
@@ -265,6 +269,18 @@ export function EccnHistoryView({
   useEffect(() => {
     setQuery(initialQuery);
   }, [initialQuery]);
+
+  useEffect(() => {
+    setSelectedCode(externalSelectedCode);
+  }, [externalSelectedCode]);
+
+  const updateSelectedCode = useCallback(
+    (value: string) => {
+      setSelectedCode(value);
+      onSelectedCodeChange?.(value);
+    },
+    [onSelectedCodeChange]
+  );
 
   const updateQuery = (value: string) => {
     setQuery(value);
@@ -304,11 +320,14 @@ export function EccnHistoryView({
     if (!selectedCode) {
       return;
     }
+    if (options.length === 0) {
+      return;
+    }
     const normalized = normalizeCode(selectedCode);
     if (!options.some((option) => option.normalizedCode === normalized)) {
-      setSelectedCode('');
+      updateSelectedCode('');
     }
-  }, [options, selectedCode]);
+  }, [options, selectedCode, updateSelectedCode]);
 
   useEffect(() => {
     if (!normalizedSelected || versions.length === 0) {
@@ -385,16 +404,16 @@ export function EccnHistoryView({
     const normalized = normalizeCode(trimmed);
     const match = options.find((option) => option.normalizedCode === normalized);
     if (match) {
-      setSelectedCode(match.entry.eccn);
+      updateSelectedCode(match.entry.eccn);
       updateQuery(match.entry.eccn);
     } else {
-      setSelectedCode(normalized);
+      updateSelectedCode(normalized);
       updateQuery(normalized);
     }
   };
 
   const handleSelectOption = (option: HistorySearchOption) => {
-    setSelectedCode(option.entry.eccn);
+    updateSelectedCode(option.entry.eccn);
     updateQuery(option.entry.eccn);
   };
 

--- a/client/src/components/EccnHistoryView.tsx
+++ b/client/src/components/EccnHistoryView.tsx
@@ -22,6 +22,8 @@ interface EccnHistoryViewProps {
   ensureDataset: (date: string) => Promise<CclDataset>;
   loadingVersions: boolean;
   onNavigateToEccn: (eccn: string) => void;
+  query?: string;
+  onQueryChange?: (value: string) => void;
 }
 
 type HistoryChildDetail = {
@@ -251,12 +253,23 @@ export function EccnHistoryView({
   ensureDataset,
   loadingVersions,
   onNavigateToEccn,
+  query: initialQuery = '',
+  onQueryChange,
 }: EccnHistoryViewProps) {
-  const [query, setQuery] = useState('');
+  const [query, setQuery] = useState(initialQuery);
   const [selectedCode, setSelectedCode] = useState('');
   const [historyEntries, setHistoryEntries] = useState<HistoryVersionEntry[]>([]);
   const [loadingHistory, setLoadingHistory] = useState(false);
   const [historyError, setHistoryError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setQuery(initialQuery);
+  }, [initialQuery]);
+
+  const updateQuery = (value: string) => {
+    setQuery(value);
+    onQueryChange?.(value);
+  };
 
   const normalizedQuery = useMemo(() => normalizeSearchValue(query), [query]);
   const normalizedSelected = useMemo(() => normalizeCode(selectedCode), [selectedCode]);
@@ -373,16 +386,16 @@ export function EccnHistoryView({
     const match = options.find((option) => option.normalizedCode === normalized);
     if (match) {
       setSelectedCode(match.entry.eccn);
-      setQuery(match.entry.eccn);
+      updateQuery(match.entry.eccn);
     } else {
       setSelectedCode(normalized);
-      setQuery(normalized);
+      updateQuery(normalized);
     }
   };
 
   const handleSelectOption = (option: HistorySearchOption) => {
     setSelectedCode(option.entry.eccn);
-    setQuery(option.entry.eccn);
+    updateQuery(option.entry.eccn);
   };
 
   const childOrder = useMemo(() => {
@@ -432,7 +445,7 @@ export function EccnHistoryView({
               className="control"
               type="search"
               value={query}
-              onChange={(event) => setQuery(event.target.value)}
+              onChange={(event) => updateQuery(event.target.value)}
               placeholder="Search by code or keyword"
               autoComplete="off"
             />

--- a/client/src/components/TradeDataView.tsx
+++ b/client/src/components/TradeDataView.tsx
@@ -1,13 +1,28 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { tradeDataByEccn } from '../data/tradeData';
 import { formatNumber, formatPercent, formatUsd } from '../utils/format';
 
 interface TradeDataViewProps {
+  query?: string;
+  onQueryChange?: (value: string) => void;
   onNavigateToEccn?: (eccn: string) => void;
 }
 
-export function TradeDataView({ onNavigateToEccn }: TradeDataViewProps) {
-  const [query, setQuery] = useState('');
+export function TradeDataView({
+  onNavigateToEccn,
+  query: initialQuery = '',
+  onQueryChange,
+}: TradeDataViewProps) {
+  const [query, setQuery] = useState(initialQuery);
+
+  useEffect(() => {
+    setQuery(initialQuery);
+  }, [initialQuery]);
+
+  const handleQueryChange = (value: string) => {
+    setQuery(value);
+    onQueryChange?.(value);
+  };
   const normalizedQuery = query.trim().toLowerCase();
 
   const filteredRecords = useMemo(() => {
@@ -108,7 +123,7 @@ export function TradeDataView({ onNavigateToEccn }: TradeDataViewProps) {
             className="control"
             type="search"
             value={query}
-            onChange={(event) => setQuery(event.target.value)}
+            onChange={(event) => handleQueryChange(event.target.value)}
             placeholder="Search by ECCN, keyword, or notes"
           />
           <p className="help-text">

--- a/client/src/utils/format.ts
+++ b/client/src/utils/format.ts
@@ -8,7 +8,7 @@ export function formatDate(dateString?: string): string {
     // Interpret API-provided YYYY-MM-DD dates as calendar dates without a
     // timezone component so they display consistently regardless of the
     // viewer's locale.
-    const [_, year, month, day] = isoDateOnlyMatch;
+    const [, year, month, day] = isoDateOnlyMatch;
     const date = new Date(`${year}-${month}-${day}T00:00:00Z`);
     if (Number.isNaN(date.getTime())) {
       return dateString;


### PR DESCRIPTION
## Summary
- sync the active tab and the major search inputs with URL query parameters so state survives reloads and deep links
- initialize tab/search state from the URL and respond to browser navigation events
- allow the history and trade views to receive externally managed queries so filters remain in sync

## Testing
- npm run lint --prefix client
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68debe75de24832f8419592949206a0a