### PR TITLE
Generate per-ECCN history snapshots and client loader

### DIFF
--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -1,5 +1,6 @@
 import {
   CclDataset,
+  EccnHistoryResponse,
   FederalRegisterDocumentsResponse,
   FederalRegisterRefreshStatus,
   VersionsResponse,
@@ -56,6 +57,12 @@ export async function reparseStoredCcls(): Promise<{
     body: JSON.stringify({}),
   });
   return handleResponse<{ message: string; processedDates: { date: string; fetchedAt: string }[] }>(res);
+}
+
+export async function getEccnHistory(eccn: string): Promise<EccnHistoryResponse> {
+  const normalized = eccn.trim().toUpperCase().replace(/\s+/g, '');
+  const res = await fetch(`/api/ccl/history/${encodeURIComponent(normalized)}`);
+  return handleResponse<EccnHistoryResponse>(res);
 }
 
 export async function getFederalRegisterDocuments(): Promise<FederalRegisterDocumentsResponse> {

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -57,6 +57,32 @@ export interface CclDataset {
   supplements: CclSupplement[];
 }
 
+export interface EccnHistoryVersionEntry {
+  version: string;
+  fetchedAt: string | null;
+  sourceUrl: string | null;
+  heading?: string | null;
+  title?: string | null;
+  category?: string | null;
+  group?: string | null;
+  supplement?: { number: string; heading?: string | null } | null;
+  breadcrumbs?: string[];
+  ancestors: string[];
+  text: string;
+  structure?: EccnNode | null;
+}
+
+export interface EccnHistoryLeaf {
+  eccn: string;
+  normalized?: string;
+  history: EccnHistoryVersionEntry[];
+}
+
+export interface EccnHistoryResponse {
+  eccn: string;
+  leaves: EccnHistoryLeaf[];
+}
+
 export interface VersionSummary {
   date: string;
   fetchedAt: string;


### PR DESCRIPTION
## Summary
- generate ECCN history JSON files when parsing datasets and rebuild them on reparse
- expose `/api/ccl/history/:eccn` so the client can request precomputed leaf histories
- update the history view to fetch the new data and compare child ECCNs without loading whole datasets

## Testing
- npm run build --prefix client

------
https://chatgpt.com/codex/tasks/task_e_68ded9a59fd4832f8940dc59f30b8c7c