### PR TITLE
Align ECCN history search with explorer

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -182,6 +182,8 @@ body {
   max-height: 50vh;
   overflow-y: auto;
   padding-right: 0.35rem;
+  box-sizing: border-box;
+  overflow-x: hidden;
 }
 
 .history-option-item {
@@ -914,6 +916,8 @@ body {
   overflow-y: auto;
   max-height: 50vh;
   padding-right: 0.35rem;
+  box-sizing: border-box;
+  overflow-x: hidden;
 }
 
 .eccn-list li button {

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -200,6 +200,13 @@ body {
   font-weight: 500;
 }
 
+.history-option-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
 .history-option-button:hover {
   border-color: #94a3b8;
   transform: translateY(-1px);
@@ -213,6 +220,18 @@ body {
 
 .history-option-code {
   font-weight: 600;
+}
+
+.history-option-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.05rem 0.6rem;
+  border-radius: 999px;
+  background: #dbeafe;
+  color: #1d4ed8;
+  font-size: 0.75rem;
+  font-weight: 600;
+  white-space: nowrap;
 }
 
 .history-option-title {

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -178,26 +178,31 @@ body {
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  max-height: 420px;
-  overflow: auto;
+  gap: 0.35rem;
+  max-height: 50vh;
+  overflow-y: auto;
+  padding-right: 0.35rem;
+}
+
+.history-option-item {
+  list-style: none;
 }
 
 .history-option-button {
   width: 100%;
   text-align: left;
-  padding: 0.65rem 0.85rem;
+  border: 1px solid #e5e7eb;
   border-radius: 0.75rem;
-  border: 1px solid #e2e8f0;
-  background: #f8fafc;
-  color: #0f172a;
+  background: #f9fafb;
+  padding: 0.6rem 0.75rem;
   display: flex;
   flex-direction: column;
-  gap: 0.2rem;
-  cursor: pointer;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.15s ease;
+  gap: 0.25rem;
   font-size: 0.95rem;
-  font-weight: 500;
+  font-family: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  cursor: pointer;
+  color: inherit;
 }
 
 .history-option-header {
@@ -207,19 +212,16 @@ body {
   gap: 0.5rem;
 }
 
+.history-option-item.active .history-option-button,
 .history-option-button:hover {
-  border-color: #94a3b8;
-  transform: translateY(-1px);
-}
-
-.history-option-button[data-active='true'] {
   border-color: #2563eb;
-  background: #eef2ff;
-  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.15);
+  background: rgba(37, 99, 235, 0.08);
+  box-shadow: 0 4px 12px rgba(37, 99, 235, 0.2);
 }
 
 .history-option-code {
-  font-weight: 600;
+  font-weight: 700;
+  color: #1f2937;
 }
 
 .history-option-tag {
@@ -235,8 +237,8 @@ body {
 }
 
 .history-option-title {
-  font-size: 0.85rem;
-  color: #475569;
+  font-size: 0.9rem;
+  color: #4b5563;
 }
 
 .history-area {

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -33,9 +33,9 @@ import { formatDateTime, formatNumber } from './utils/format';
 import {
   ECCN_ALLOWED_CHARS_PATTERN,
   buildEccnSearchTarget,
-  eccnSegmentsMatchQuery,
+  matchesEccnSearchTarget,
+  prepareEccnSearchQuery,
   extractEccnQuery,
-  normalizeSearchText,
   parseNormalizedEccn,
   type EccnSegment,
 } from './utils/eccnSearch';
@@ -1358,12 +1358,9 @@ function App() {
     return map;
   }, [allEccns]);
 
-  const filteredEccns: EccnEntry[] = useMemo(() => {
-    const normalizedTerm = normalizeSearchText(eccnFilter);
-    const tokens = normalizedTerm.split(/\s+/).filter(Boolean);
-    const eccnQuery = extractEccnQuery(eccnFilter);
-    const querySegments = eccnQuery?.segments ?? null;
+  const explorerSearchQuery = useMemo(() => prepareEccnSearchQuery(eccnFilter), [eccnFilter]);
 
+  const filteredEccns: EccnEntry[] = useMemo(() => {
     if (selectedSupplements.length === 0) {
       return [];
     }
@@ -1373,20 +1370,11 @@ function App() {
         if (!selectedSupplements.includes(entry.supplement.number)) {
           return false;
         }
-        if (querySegments) {
-          if (!segments) {
-            return false;
-          }
 
-          return eccnSegmentsMatchQuery(querySegments, segments);
-        }
-        if (tokens.length === 0) {
-          return true;
-        }
-        return tokens.every((token) => searchText.includes(token));
+        return matchesEccnSearchTarget(explorerSearchQuery, { searchText, segments });
       })
       .map(({ entry }) => entry);
-  }, [searchableEccns, eccnFilter, selectedSupplements]);
+  }, [searchableEccns, selectedSupplements, explorerSearchQuery]);
 
   const singleSelectedSupplement = useMemo(() => {
     if (selectedSupplements.length !== 1) {

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1921,29 +1921,33 @@ function App() {
                         </div>
     
                         <ul className="eccn-list">
-                          {filteredEccns.map((entry) => (
-                            <li
-                              key={`${entry.supplement.number}-${entry.eccn}`}
-                              className={entry.eccn === activeEccn?.eccn ? 'active' : ''}
-                            >
-                              <button type="button" onClick={() => handleSelectEccn(entry.eccn)}>
-                                <div className="eccn-list-header">
-                                  <span className="eccn-code">{entry.eccn}</span>
-                                  <span
-                                    className="eccn-tag"
-                                    title={
-                                      entry.supplement.heading
-                                        ? `Supplement No. ${entry.supplement.number} – ${entry.supplement.heading}`
-                                        : `Supplement No. ${entry.supplement.number}`
-                                    }
-                                  >
-                                    {`Supp. No. ${entry.supplement.number}`}
-                                  </span>
-                                </div>
-                                {entry.title && <span className="eccn-title">{entry.title}</span>}
-                              </button>
-                            </li>
-                          ))}
+                          {filteredEccns.map((entry) => {
+                            const trimmedCode = entry.eccn.trim();
+                            const displayCode = trimmedCode || entry.eccn;
+                            return (
+                              <li
+                                key={`${entry.supplement.number}-${entry.eccn}`}
+                                className={entry.eccn === activeEccn?.eccn ? 'active' : ''}
+                              >
+                                <button type="button" onClick={() => handleSelectEccn(entry.eccn)}>
+                                  <div className="eccn-list-header">
+                                    <span className="eccn-code">{displayCode}</span>
+                                    <span
+                                      className="eccn-tag"
+                                      title={
+                                        entry.supplement.heading
+                                          ? `Supplement No. ${entry.supplement.number} – ${entry.supplement.heading}`
+                                          : `Supplement No. ${entry.supplement.number}`
+                                      }
+                                    >
+                                      {`Supp. No. ${entry.supplement.number}`}
+                                    </span>
+                                  </div>
+                                  {entry.title && <span className="eccn-title">{entry.title}</span>}
+                                </button>
+                              </li>
+                            );
+                          })}
                         </ul>
                       </aside>
     

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -35,6 +35,7 @@ import {
   buildEccnSearchTarget,
   eccnSegmentsMatchQuery,
   extractEccnQuery,
+  ECCN_SEARCH_DEFAULT_LIMIT,
   normalizeSearchText,
   parseNormalizedEccn,
   truncateEccnTitle,
@@ -1360,6 +1361,7 @@ function App() {
   }, [allEccns]);
 
   const filteredEccns: EccnEntry[] = useMemo(() => {
+    const trimmedFilter = eccnFilter.trim();
     const normalizedTerm = normalizeSearchText(eccnFilter);
     const tokens = normalizedTerm.split(/\s+/).filter(Boolean);
     const eccnQuery = extractEccnQuery(eccnFilter);
@@ -1369,7 +1371,7 @@ function App() {
       return [];
     }
 
-    return searchableEccns
+    const matches = searchableEccns
       .filter(({ entry, searchText, segments }) => {
         if (!selectedSupplements.includes(entry.supplement.number)) {
           return false;
@@ -1390,6 +1392,12 @@ function App() {
         return tokens.every((token) => searchText.includes(token));
       })
       .map(({ entry }) => entry);
+
+    if (!trimmedFilter) {
+      return matches.slice(0, ECCN_SEARCH_DEFAULT_LIMIT);
+    }
+
+    return matches;
   }, [searchableEccns, selectedSupplements, eccnFilter]);
 
   const singleSelectedSupplement = useMemo(() => {

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -30,10 +30,15 @@ import { TradeDataView } from './components/TradeDataView';
 import { FederalRegisterTimeline } from './components/FederalRegisterTimeline';
 import { EccnHistoryView } from './components/EccnHistoryView';
 import { formatDateTime, formatNumber } from './utils/format';
-
-const ECCN_BASE_PATTERN = /^[0-9][A-Z][0-9]{3}$/;
-const ECCN_SEGMENT_PATTERN = /^[A-Z0-9]+(?:-[A-Z0-9]+)*$/;
-const ECCN_ALLOWED_CHARS_PATTERN = /^[0-9A-Z.\-\s]+$/;
+import {
+  ECCN_ALLOWED_CHARS_PATTERN,
+  buildEccnSearchTarget,
+  eccnSegmentsMatchQuery,
+  extractEccnQuery,
+  normalizeSearchText,
+  parseNormalizedEccn,
+  type EccnSegment,
+} from './utils/eccnSearch';
 const SCROLL_TOP_THRESHOLD = 480;
 
 type AppTab = 'explorer' | 'history' | 'trade' | 'federal-register' | 'settings';
@@ -118,189 +123,12 @@ function readInitialUrlState(): UrlState {
   return getUrlStateFromSearch(window.location.search);
 }
 
-type EccnSegment = {
-  raw: string;
-  parts: string[];
-};
-
-type ParsedEccnCode = {
-  code: string;
-  segments: EccnSegment[];
-};
-
 type SearchableEccn = {
   entry: EccnEntry;
   searchText: string;
   normalizedCode: string;
   segments: EccnSegment[] | null;
 };
-
-function stripWrappingPunctuation(value: string): string {
-  let working = value.trim();
-
-  while (working && /[).,;:–—]+$/u.test(working)) {
-    working = working.replace(/[).,;:–—]+$/u, '').trimEnd();
-  }
-
-  while (working && /^[([{"'`]+/u.test(working)) {
-    working = working.replace(/^[([{"'`]+/u, '').trimStart();
-  }
-
-  return working;
-}
-
-function parseNormalizedEccn(value: string | null | undefined): ParsedEccnCode | null {
-  if (!value) {
-    return null;
-  }
-
-  const trimmed = value.trim().toUpperCase();
-  if (!trimmed) {
-    return null;
-  }
-
-  const squished = trimmed.replace(/\s+/g, '');
-  if (!squished) {
-    return null;
-  }
-
-  if (squished.length < 5) {
-    return null;
-  }
-
-  const base = squished.slice(0, 5);
-  if (!ECCN_BASE_PATTERN.test(base)) {
-    return null;
-  }
-  const segments: EccnSegment[] = [
-    {
-      raw: base,
-      parts: base.split('-'),
-    },
-  ];
-
-  let index = base.length;
-
-  while (index < squished.length) {
-    if (squished[index] !== '.') {
-      return null;
-    }
-    index += 1;
-
-    const segmentStart = index;
-    while (index < squished.length && squished[index] !== '.') {
-      index += 1;
-    }
-
-    const segmentRaw = squished.slice(segmentStart, index);
-    if (!segmentRaw) {
-      return null;
-    }
-    if (!ECCN_SEGMENT_PATTERN.test(segmentRaw)) {
-      return null;
-    }
-
-    segments.push({
-      raw: segmentRaw,
-      parts: segmentRaw.split('-'),
-    });
-  }
-
-  return {
-    code: segments.map((segment) => segment.raw).join('.'),
-    segments,
-  };
-}
-
-function eccnSegmentsMatchQuery(querySegments: EccnSegment[], entrySegments: EccnSegment[]): boolean {
-  if (!querySegments.length || !entrySegments.length) {
-    return false;
-  }
-
-  if (entrySegments[0].raw !== querySegments[0].raw) {
-    return false;
-  }
-
-  if (entrySegments.length < querySegments.length) {
-    return false;
-  }
-
-  return querySegments.every((querySegment, index) => {
-    const target = entrySegments[index];
-    if (!target) {
-      return false;
-    }
-
-    if (index === 0) {
-      return target.raw === querySegment.raw;
-    }
-
-    if (target.raw === querySegment.raw) {
-      return true;
-    }
-
-    if (target.parts.length < querySegment.parts.length) {
-      return false;
-    }
-
-    return querySegment.parts.every((part, partIndex) => target.parts[partIndex] === part);
-  });
-}
-
-function normalizeSearchText(value: string | null | undefined): string {
-  if (!value) {
-    return '';
-  }
-
-  return value
-    .normalize('NFKD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, ' ')
-    .trim();
-}
-
-function buildEccnSearchTarget(entry: EccnEntry): string {
-  const fields: Array<string | null | undefined> = [
-    entry.eccn,
-    entry.heading,
-    entry.title,
-    entry.category ? `category ${entry.category}` : null,
-    entry.group ? `group ${entry.group}` : null,
-    entry.parentEccn ? `parent ${entry.parentEccn}` : null,
-    entry.childEccns && entry.childEccns.length > 0 ? entry.childEccns.join(' ') : null,
-    entry.breadcrumbs.length > 0 ? entry.breadcrumbs.join(' ') : null,
-    entry.supplement?.heading,
-    entry.supplement?.number,
-    entry.supplement ? `supplement ${entry.supplement.number}` : null,
-    entry.supplement ? `supp no ${entry.supplement.number}` : null,
-  ];
-
-  return normalizeSearchText(fields.filter(Boolean).join(' '));
-}
-
-function extractEccnQuery(value: string | null | undefined): ParsedEccnCode | null {
-  if (!value) {
-    return null;
-  }
-
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return null;
-  }
-
-  const stripped = stripWrappingPunctuation(trimmed);
-  if (!stripped) {
-    return null;
-  }
-
-  const upper = stripped.toUpperCase();
-  if (!ECCN_ALLOWED_CHARS_PATTERN.test(upper)) {
-    return null;
-  }
-
-  return parseNormalizedEccn(upper);
-}
 
 interface HighLevelField {
   id: string;
@@ -1505,12 +1333,12 @@ function App() {
     () => {
       const unique = new Map<
         string,
-        { entry: EccnEntry; normalizedCode: string; searchText: string }
+        { entry: EccnEntry; normalizedCode: string; searchText: string; segments: EccnSegment[] | null }
       >();
 
-      searchableEccns.forEach(({ entry, normalizedCode, searchText }) => {
+      searchableEccns.forEach(({ entry, normalizedCode, searchText, segments }) => {
         if (!unique.has(normalizedCode)) {
-          unique.set(normalizedCode, { entry, normalizedCode, searchText });
+          unique.set(normalizedCode, { entry, normalizedCode, searchText, segments });
         }
       });
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -37,6 +37,7 @@ import {
   extractEccnQuery,
   normalizeSearchText,
   parseNormalizedEccn,
+  truncateEccnTitle,
   type EccnSegment,
 } from './utils/eccnSearch';
 const SCROLL_TOP_THRESHOLD = 480;
@@ -1925,7 +1926,8 @@ function App() {
                             const trimmedCode = entry.eccn.trim();
                             const displayCode = trimmedCode || entry.eccn;
                             const trimmedTitle = entry.title?.trim();
-                            const displayTitle = trimmedTitle ?? entry.title;
+                            const displayTitle = trimmedTitle ?? entry.title ?? null;
+                            const previewTitle = truncateEccnTitle(displayTitle);
                             return (
                               <li
                                 key={`${entry.supplement.number}-${entry.eccn}`}
@@ -1945,8 +1947,10 @@ function App() {
                                       {`Supp. No. ${entry.supplement.number}`}
                                     </span>
                                   </div>
-                                  {displayTitle && (
-                                    <span className="eccn-title">{displayTitle}</span>
+                                  {previewTitle && (
+                                    <span className="eccn-title" title={displayTitle ?? undefined}>
+                                      {previewTitle}
+                                    </span>
                                   )}
                                 </button>
                               </li>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1924,6 +1924,8 @@ function App() {
                           {filteredEccns.map((entry) => {
                             const trimmedCode = entry.eccn.trim();
                             const displayCode = trimmedCode || entry.eccn;
+                            const trimmedTitle = entry.title?.trim();
+                            const displayTitle = trimmedTitle ?? entry.title;
                             return (
                               <li
                                 key={`${entry.supplement.number}-${entry.eccn}`}
@@ -1943,7 +1945,9 @@ function App() {
                                       {`Supp. No. ${entry.supplement.number}`}
                                     </span>
                                   </div>
-                                  {entry.title && <span className="eccn-title">{entry.title}</span>}
+                                  {displayTitle && (
+                                    <span className="eccn-title">{displayTitle}</span>
+                                  )}
                                 </button>
                               </li>
                             );

--- a/client/src/components/EccnHistoryView.tsx
+++ b/client/src/components/EccnHistoryView.tsx
@@ -426,6 +426,8 @@ export function EccnHistoryView({
           <ul className="history-option-list" role="list">
             {filteredOptions.map((option) => {
               const isActive = option.normalizedCode === normalizedSelected;
+              const trimmedCode = option.entry.eccn.trim();
+              const displayCode = trimmedCode || option.entry.eccn;
               return (
                 <li
                   key={option.normalizedCode}
@@ -437,7 +439,7 @@ export function EccnHistoryView({
                     onClick={() => handleSelectOption(option)}
                   >
                     <div className="history-option-header">
-                      <span className="history-option-code">{option.entry.eccn}</span>
+                      <span className="history-option-code">{displayCode}</span>
                       {option.entry.supplement ? (
                         <span
                           className="history-option-tag"

--- a/client/src/components/EccnHistoryView.tsx
+++ b/client/src/components/EccnHistoryView.tsx
@@ -425,37 +425,42 @@ export function EccnHistoryView({
             </p>
           </form>
           <ul className="history-option-list" role="list">
-            {filteredOptions.map((option) => (
-              <li key={option.normalizedCode}>
-                <button
-                  type="button"
-                  className="history-option-button"
-                  data-active={option.normalizedCode === normalizedSelected}
-                  onClick={() => handleSelectOption(option)}
+            {filteredOptions.map((option) => {
+              const isActive = option.normalizedCode === normalizedSelected;
+              return (
+                <li
+                  key={option.normalizedCode}
+                  className={`history-option-item${isActive ? ' active' : ''}`}
                 >
-                  <div className="history-option-header">
-                    <span className="history-option-code">{option.entry.eccn}</span>
-                    {option.entry.supplement ? (
-                      <span
-                        className="history-option-tag"
-                        title={
-                          option.entry.supplement.heading
-                            ? `Supplement No. ${option.entry.supplement.number} – ${option.entry.supplement.heading}`
-                            : `Supplement No. ${option.entry.supplement.number}`
-                        }
-                      >
-                        {`Supp. No. ${option.entry.supplement.number}`}
-                      </span>
+                  <button
+                    type="button"
+                    className="history-option-button"
+                    onClick={() => handleSelectOption(option)}
+                  >
+                    <div className="history-option-header">
+                      <span className="history-option-code">{option.entry.eccn}</span>
+                      {option.entry.supplement ? (
+                        <span
+                          className="history-option-tag"
+                          title={
+                            option.entry.supplement.heading
+                              ? `Supplement No. ${option.entry.supplement.number} – ${option.entry.supplement.heading}`
+                              : `Supplement No. ${option.entry.supplement.number}`
+                          }
+                        >
+                          {`Supp. No. ${option.entry.supplement.number}`}
+                        </span>
+                      ) : null}
+                    </div>
+                    {option.entry.title ? (
+                      <span className="history-option-title">{option.entry.title}</span>
+                    ) : option.entry.heading ? (
+                      <span className="history-option-title">{option.entry.heading}</span>
                     ) : null}
-                  </div>
-                  {option.entry.title ? (
-                    <span className="history-option-title">{option.entry.title}</span>
-                  ) : option.entry.heading ? (
-                    <span className="history-option-title">{option.entry.heading}</span>
-                  ) : null}
-                </button>
-              </li>
-            ))}
+                  </button>
+                </li>
+              );
+            })}
           </ul>
         </section>
       </aside>

--- a/client/src/components/EccnHistoryView.tsx
+++ b/client/src/components/EccnHistoryView.tsx
@@ -233,8 +233,6 @@ export function EccnHistoryView({
     });
   }, [options, trimmedQuery, querySegments, queryTokens]);
 
-  const limitedOptions = useMemo(() => filteredOptions.slice(0, 200), [filteredOptions]);
-
   const selectedOption = useMemo(
     () => options.find((option) => option.normalizedCode === normalizedSelected) ?? null,
     [options, normalizedSelected]
@@ -423,12 +421,11 @@ export function EccnHistoryView({
               autoComplete="off"
             />
             <p className="help-text">
-              Showing {formatNumber(limitedOptions.length)} of {formatNumber(options.length)} ECCNs.
-              {filteredOptions.length > limitedOptions.length ? ' Narrow your search to see more.' : ''}
+              Showing {formatNumber(filteredOptions.length)} of {formatNumber(options.length)} ECCNs.
             </p>
           </form>
           <ul className="history-option-list" role="list">
-            {limitedOptions.map((option) => (
+            {filteredOptions.map((option) => (
               <li key={option.normalizedCode}>
                 <button
                   type="button"
@@ -436,7 +433,21 @@ export function EccnHistoryView({
                   data-active={option.normalizedCode === normalizedSelected}
                   onClick={() => handleSelectOption(option)}
                 >
-                  <span className="history-option-code">{option.entry.eccn}</span>
+                  <div className="history-option-header">
+                    <span className="history-option-code">{option.entry.eccn}</span>
+                    {option.entry.supplement ? (
+                      <span
+                        className="history-option-tag"
+                        title={
+                          option.entry.supplement.heading
+                            ? `Supplement No. ${option.entry.supplement.number} – ${option.entry.supplement.heading}`
+                            : `Supplement No. ${option.entry.supplement.number}`
+                        }
+                      >
+                        {`Supp. No. ${option.entry.supplement.number}`}
+                      </span>
+                    ) : null}
+                  </div>
                   {option.entry.title ? (
                     <span className="history-option-title">{option.entry.title}</span>
                   ) : option.entry.heading ? (

--- a/client/src/components/EccnHistoryView.tsx
+++ b/client/src/components/EccnHistoryView.tsx
@@ -13,6 +13,7 @@ import {
   eccnSegmentsMatchQuery,
   extractEccnQuery,
   normalizeSearchText,
+  truncateEccnTitle,
   type EccnSegment,
 } from '../utils/eccnSearch';
 
@@ -430,7 +431,8 @@ export function EccnHistoryView({
               const displayCode = trimmedCode || option.entry.eccn;
               const trimmedTitle = option.entry.title?.trim();
               const trimmedHeading = option.entry.heading?.trim();
-              const displayTitle = trimmedTitle || trimmedHeading;
+              const displayTitle = trimmedTitle || trimmedHeading || null;
+              const previewTitle = truncateEccnTitle(displayTitle);
               return (
                 <li
                   key={option.normalizedCode}
@@ -456,8 +458,10 @@ export function EccnHistoryView({
                         </span>
                       ) : null}
                     </div>
-                    {displayTitle ? (
-                      <span className="history-option-title">{displayTitle}</span>
+                    {previewTitle ? (
+                      <span className="history-option-title" title={displayTitle ?? undefined}>
+                        {previewTitle}
+                      </span>
                     ) : null}
                   </button>
                 </li>

--- a/client/src/components/EccnHistoryView.tsx
+++ b/client/src/components/EccnHistoryView.tsx
@@ -10,9 +10,8 @@ import {
 import { formatDateTime, formatNumber } from '../utils/format';
 import { EccnNodeView } from './EccnNodeView';
 import {
-  eccnSegmentsMatchQuery,
-  extractEccnQuery,
-  normalizeSearchText,
+  matchesEccnSearchTarget,
+  prepareEccnSearchQuery,
   type EccnSegment,
 } from '../utils/eccnSearch';
 
@@ -201,33 +200,17 @@ export function EccnHistoryView({
     onQueryChange?.(value);
   };
 
-  const normalizedQuery = useMemo(() => normalizeSearchText(query), [query]);
   const normalizedSelected = useMemo(() => normalizeCode(selectedCode), [selectedCode]);
 
-  const queryTokens = useMemo(
-    () => (normalizedQuery ? normalizedQuery.split(/\s+/).filter(Boolean) : []),
-    [normalizedQuery]
-  );
-  const eccnQuery = useMemo(() => extractEccnQuery(query), [query]);
+  const preparedQuery = useMemo(() => prepareEccnSearchQuery(query), [query]);
 
   const filteredOptions = useMemo(() => {
-    const trimmed = query.trim();
-    if (!trimmed) {
+    if (!preparedQuery.trimmed) {
       return options;
     }
 
-    return options.filter((option) => {
-      if (eccnQuery?.segments && option.segments) {
-        if (eccnSegmentsMatchQuery(eccnQuery.segments, option.segments)) {
-          return true;
-        }
-      }
-      if (queryTokens.length === 0) {
-        return false;
-      }
-      return queryTokens.every((token) => option.searchText.includes(token));
-    });
-  }, [options, query, eccnQuery, queryTokens]);
+    return options.filter((option) => matchesEccnSearchTarget(preparedQuery, option));
+  }, [options, preparedQuery]);
 
   const limitedOptions = useMemo(() => filteredOptions.slice(0, 200), [filteredOptions]);
 

--- a/client/src/components/EccnHistoryView.tsx
+++ b/client/src/components/EccnHistoryView.tsx
@@ -311,7 +311,6 @@ export function EccnHistoryView({
 
   const handleSelectOption = (option: HistorySearchOption) => {
     updateSelectedCode(option.entry.eccn);
-    updateQuery(option.entry.eccn);
   };
 
   const preparedLeaves = useMemo<PreparedLeaf[]>(() => {

--- a/client/src/components/EccnHistoryView.tsx
+++ b/client/src/components/EccnHistoryView.tsx
@@ -12,6 +12,7 @@ import { EccnNodeView } from './EccnNodeView';
 import {
   eccnSegmentsMatchQuery,
   extractEccnQuery,
+  ECCN_SEARCH_DEFAULT_LIMIT,
   normalizeSearchText,
   truncateEccnTitle,
   type EccnSegment,
@@ -214,7 +215,7 @@ export function EccnHistoryView({
 
   const filteredOptions = useMemo(() => {
     if (!trimmedQuery) {
-      return options;
+      return options.slice(0, ECCN_SEARCH_DEFAULT_LIMIT);
     }
 
     return options.filter(({ searchText, segments }) => {

--- a/client/src/components/EccnHistoryView.tsx
+++ b/client/src/components/EccnHistoryView.tsx
@@ -428,6 +428,9 @@ export function EccnHistoryView({
               const isActive = option.normalizedCode === normalizedSelected;
               const trimmedCode = option.entry.eccn.trim();
               const displayCode = trimmedCode || option.entry.eccn;
+              const trimmedTitle = option.entry.title?.trim();
+              const trimmedHeading = option.entry.heading?.trim();
+              const displayTitle = trimmedTitle || trimmedHeading;
               return (
                 <li
                   key={option.normalizedCode}
@@ -453,10 +456,8 @@ export function EccnHistoryView({
                         </span>
                       ) : null}
                     </div>
-                    {option.entry.title ? (
-                      <span className="history-option-title">{option.entry.title}</span>
-                    ) : option.entry.heading ? (
-                      <span className="history-option-title">{option.entry.heading}</span>
+                    {displayTitle ? (
+                      <span className="history-option-title">{displayTitle}</span>
                     ) : null}
                   </button>
                 </li>

--- a/client/src/utils/eccnSearch.ts
+++ b/client/src/utils/eccnSearch.ts
@@ -23,6 +23,7 @@ export type PreparedEccnSearchQuery = {
 };
 
 export const ECCN_TITLE_PREVIEW_LIMIT = 120;
+export const ECCN_SEARCH_DEFAULT_LIMIT = 100;
 
 export function truncateEccnTitle(
   title: string | null | undefined,

--- a/client/src/utils/eccnSearch.ts
+++ b/client/src/utils/eccnSearch.ts
@@ -1,0 +1,185 @@
+import type { EccnEntry } from '../types';
+
+export const ECCN_BASE_PATTERN = /^[0-9][A-Z][0-9]{3}$/;
+export const ECCN_SEGMENT_PATTERN = /^[A-Z0-9]+(?:-[A-Z0-9]+)*$/;
+export const ECCN_ALLOWED_CHARS_PATTERN = /^[0-9A-Z.\-\s]+$/;
+
+export type EccnSegment = {
+  raw: string;
+  parts: string[];
+};
+
+export type ParsedEccnCode = {
+  code: string;
+  segments: EccnSegment[];
+};
+
+function stripWrappingPunctuation(value: string): string {
+  let working = value.trim();
+
+  while (working && /[).,;:–—]+$/u.test(working)) {
+    working = working.replace(/[).,;:–—]+$/u, '').trimEnd();
+  }
+
+  while (working && /^[([{"'`]+/u.test(working)) {
+    working = working.replace(/^[([{"'`]+/u, '').trimStart();
+  }
+
+  return working;
+}
+
+export function parseNormalizedEccn(value: string | null | undefined): ParsedEccnCode | null {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = value.trim().toUpperCase();
+  if (!trimmed) {
+    return null;
+  }
+
+  const squished = trimmed.replace(/\s+/g, '');
+  if (!squished) {
+    return null;
+  }
+
+  if (squished.length < 5) {
+    return null;
+  }
+
+  const base = squished.slice(0, 5);
+  if (!ECCN_BASE_PATTERN.test(base)) {
+    return null;
+  }
+  const segments: EccnSegment[] = [
+    {
+      raw: base,
+      parts: base.split('-'),
+    },
+  ];
+
+  let index = base.length;
+
+  while (index < squished.length) {
+    if (squished[index] !== '.') {
+      return null;
+    }
+    index += 1;
+
+    const segmentStart = index;
+    while (index < squished.length && squished[index] !== '.') {
+      index += 1;
+    }
+
+    const segmentRaw = squished.slice(segmentStart, index);
+    if (!segmentRaw) {
+      return null;
+    }
+    if (!ECCN_SEGMENT_PATTERN.test(segmentRaw)) {
+      return null;
+    }
+
+    segments.push({
+      raw: segmentRaw,
+      parts: segmentRaw.split('-'),
+    });
+  }
+
+  return {
+    code: segments.map((segment) => segment.raw).join('.'),
+    segments,
+  };
+}
+
+export function eccnSegmentsMatchQuery(
+  querySegments: EccnSegment[],
+  entrySegments: EccnSegment[]
+): boolean {
+  if (!querySegments.length || !entrySegments.length) {
+    return false;
+  }
+
+  if (entrySegments[0].raw !== querySegments[0].raw) {
+    return false;
+  }
+
+  if (entrySegments.length < querySegments.length) {
+    return false;
+  }
+
+  return querySegments.every((querySegment, index) => {
+    const target = entrySegments[index];
+    if (!target) {
+      return false;
+    }
+
+    if (index === 0) {
+      return target.raw === querySegment.raw;
+    }
+
+    if (target.raw === querySegment.raw) {
+      return true;
+    }
+
+    if (target.parts.length < querySegment.parts.length) {
+      return false;
+    }
+
+    return querySegment.parts.every((part, partIndex) => target.parts[partIndex] === part);
+  });
+}
+
+export function normalizeSearchText(value: string | null | undefined): string {
+  if (!value) {
+    return '';
+  }
+
+  return value
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+export function buildEccnSearchTarget(entry: EccnEntry): string {
+  const fields: Array<string | null | undefined> = [
+    entry.eccn,
+    entry.heading,
+    entry.title,
+    entry.category ? `category ${entry.category}` : null,
+    entry.group ? `group ${entry.group}` : null,
+    entry.parentEccn ? `parent ${entry.parentEccn}` : null,
+    entry.childEccns && entry.childEccns.length > 0 ? entry.childEccns.join(' ') : null,
+    entry.breadcrumbs.length > 0 ? entry.breadcrumbs.join(' ') : null,
+    entry.supplement?.heading,
+    entry.supplement?.number,
+    entry.supplement ? `supplement ${entry.supplement.number}` : null,
+    entry.supplement ? `supp no ${entry.supplement.number}` : null,
+  ];
+
+  return normalizeSearchText(fields.filter(Boolean).join(' '));
+}
+
+export function extractEccnQuery(value: string | null | undefined): ParsedEccnCode | null {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const stripped = stripWrappingPunctuation(trimmed);
+  if (!stripped) {
+    return null;
+  }
+
+  const upper = stripped.toUpperCase();
+  if (!ECCN_ALLOWED_CHARS_PATTERN.test(upper)) {
+    return null;
+  }
+
+  return parseNormalizedEccn(upper);
+}

--- a/client/src/utils/eccnSearch.ts
+++ b/client/src/utils/eccnSearch.ts
@@ -22,6 +22,28 @@ export type PreparedEccnSearchQuery = {
   eccn: ParsedEccnCode | null;
 };
 
+export const ECCN_TITLE_PREVIEW_LIMIT = 120;
+
+export function truncateEccnTitle(
+  title: string | null | undefined,
+  limit: number = ECCN_TITLE_PREVIEW_LIMIT
+): string | null {
+  if (!title) {
+    return null;
+  }
+
+  const trimmed = title.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  if (trimmed.length <= limit) {
+    return trimmed;
+  }
+
+  return `${trimmed.slice(0, limit).replace(/\s+$/u, '')}…`;
+}
+
 function stripWrappingPunctuation(value: string): string {
   let working = value.trim();
 


### PR DESCRIPTION
## Summary
- factor shared ECCN parsing and search helpers into a reusable utility
- include ECCN segments in history search options so they mirror explorer data
- update the ECCN History filter to reuse the explorer search logic

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dee949cf94832fa91db2c18413037a