### PR TITLE
Refine stored version picker in CCL Explorer

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -670,10 +670,23 @@ body {
   gap: 0.5rem;
 }
 
+.control-group-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
 .control-label {
   font-weight: 600;
   font-size: 0.95rem;
   color: #111827;
+}
+
+.control-label-meta {
+  font-size: 0.85rem;
+  color: #6b7280;
+  font-weight: 500;
 }
 
 .checkbox-list {
@@ -767,39 +780,6 @@ body {
   color: #6b7280;
 }
 
-.version-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.version-list li {
-  padding: 0.75rem 0.85rem;
-  border-radius: 0.75rem;
-  border: 1px solid #e5e7eb;
-  background: #f9fafb;
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-}
-
-.version-list li.active {
-  border-color: #2563eb;
-  background: rgba(37, 99, 235, 0.08);
-}
-
-.version-list dl {
-  margin: 0;
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 0.25rem 1rem;
-  font-size: 0.9rem;
-  color: #4b5563;
-}
-
 .code-chip-list {
   display: flex;
   flex-wrap: wrap;
@@ -833,10 +813,6 @@ body {
   margin: 0 auto;
 }
 
-.version-list dt {
-  font-weight: 600;
-}
-
 .badge {
   margin-left: 0.5rem;
   padding: 0.1rem 0.4rem;
@@ -860,6 +836,109 @@ body {
 .alert.info {
   background: rgba(37, 99, 235, 0.12);
   color: #1d4ed8;
+}
+
+.empty-state {
+  padding: 1rem;
+  border-radius: 0.75rem;
+  border: 1px dashed #d1d5db;
+  background: #f9fafb;
+  font-size: 0.95rem;
+  color: #6b7280;
+  text-align: center;
+}
+
+.version-selector {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.version-option {
+  position: relative;
+  display: flex;
+  border-radius: 0.85rem;
+  border: 1px solid #e5e7eb;
+  background: #f9fafb;
+  padding: 0.85rem 1rem;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.version-option input {
+  position: absolute;
+  opacity: 0;
+  inset: 0;
+  pointer-events: none;
+}
+
+.version-option:hover,
+.version-option:focus-within {
+  border-color: rgba(37, 99, 235, 0.65);
+  box-shadow: 0 10px 22px rgba(37, 99, 235, 0.12);
+}
+
+.version-option.active {
+  border-color: #2563eb;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(59, 130, 246, 0.18));
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.16);
+}
+
+.version-option.disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+  box-shadow: none;
+}
+
+.version-option-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  width: 100%;
+}
+
+.version-option-main {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: #111827;
+}
+
+.version-option-date {
+  font-size: 1.05rem;
+}
+
+.version-option-sub {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+  color: #4b5563;
+}
+
+.version-option-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  background: rgba(107, 114, 128, 0.12);
+  color: #4b5563;
+}
+
+.version-option-chip.success {
+  background: rgba(16, 185, 129, 0.15);
+  color: #047857;
+}
+
+.version-option-chip.muted {
+  background: rgba(156, 163, 175, 0.18);
+  color: #6b7280;
 }
 
 .dataset-header h2 {


### PR DESCRIPTION
## Summary
- replace the stored version dropdown and detail list with a card-style picker
- simplify the information shown in the selector while still surfacing ECCN counts and XML status
- add supporting styles, including empty-state messaging for when no versions are cached

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfff43da40832f8a460a286af239f9